### PR TITLE
重構登入與註冊頁面 + 串登入與註冊 api

### DIFF
--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -2,29 +2,40 @@ import { getAuthToken } from "./utils";
 const BASE_URL = "https://skilforapi.bocyun.tw";
 
 export const login = async (identity, email, password) => {
-  const res = await fetch(`${BASE_URL}/members/login`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      identity,
-      email,
-      password,
-    }),
-  });
-  return await res.json();
+  try {
+    const res = await fetch(`${BASE_URL}/members/login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        identity,
+        email,
+        password,
+      }),
+    });
+    /*if (!res.ok) {
+      throw new Error(res.statusText);
+    }*/
+    return await res.json();
+  } catch (error) {
+    return console.log(error.message);
+  }
 };
 
 export const getMyUserData = async () => {
-  const token = getAuthToken();
-  const res = await fetch(`${BASE_URL}/members/me`, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  return await res.json();
+  try {
+    const token = getAuthToken();
+    const res = await fetch(`${BASE_URL}/members/me`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return await res.json();
+  } catch (error) {
+    return console.log(error.message);
+  }
 };
 
 export const register = async (
@@ -35,19 +46,23 @@ export const register = async (
   password,
   checkPassword
 ) => {
-  const res = await fetch(`${BASE_URL}/members/register`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      username,
-      identity,
-      email,
-      contactEmail,
-      password,
-      checkPassword,
-    }),
-  });
-  return await res.json();
+  try {
+    const res = await fetch(`${BASE_URL}/members/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username,
+        identity,
+        email,
+        contactEmail,
+        password,
+        checkPassword,
+      }),
+    });
+    return await res.json();
+  } catch (error) {
+    return console.log(error.message);
+  }
 };

--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -1,0 +1,53 @@
+import { getAuthToken } from "./utils";
+const BASE_URL = "https://skilforapi.bocyun.tw";
+
+export const login = async (identity, email, password) => {
+  const res = await fetch(`${BASE_URL}/members/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      identity,
+      email,
+      password,
+    }),
+  });
+  return await res.json();
+};
+
+export const getMyUserData = async () => {
+  const token = getAuthToken();
+  const res = await fetch(`${BASE_URL}/members/me`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return await res.json();
+};
+
+export const register = async (
+  username,
+  identity,
+  email,
+  contactEmail,
+  password,
+  checkPassword
+) => {
+  const res = await fetch(`${BASE_URL}/members/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      username,
+      identity,
+      email,
+      contactEmail,
+      password,
+      checkPassword,
+    }),
+  });
+  return await res.json();
+};

--- a/skilfor/src/components/App/App.js
+++ b/skilfor/src/components/App/App.js
@@ -1,3 +1,4 @@
+import styled from "styled-components";
 import Nav from "../Nav";
 import Footer from "../Footer";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
@@ -13,26 +14,46 @@ import RegisterPage from "../../pages/RegisterPage";
 import TeacherCalendarPage from "../../pages/TeacherCalendarPage";
 import FilterPage from "../../pages/FilterPage";
 
+const Loading = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  text-align: center;
+`;
+
 function App() {
   const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    setIsLoading(true);
     const token = getAuthToken();
     if (!token) {
+      setIsLoading(false);
       return;
     }
     getMyUserData().then((response) => {
+      setIsLoading(false);
       if (response.success === true) {
         setUser(response.user);
       }
     });
-  });
+  }, []);
 
   return (
-    <AuthContext.Provider value={{ user, setUser }}>
+    <AuthContext.Provider value={{ user, setUser, isLoading, setIsLoading }}>
       <Router>
         <>
-          <Nav />
+          {!isLoading && <Nav />}
+          {isLoading && <Loading>載入中...</Loading>}
           <Routes>
             <Route exact path="/login" element={<LoginPage />}></Route>
             <Route exact path="/register" element={<RegisterPage />}></Route>

--- a/skilfor/src/components/App/App.js
+++ b/skilfor/src/components/App/App.js
@@ -1,6 +1,10 @@
 import Nav from "../Nav";
 import Footer from "../Footer";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { AuthContext } from "../../contexts";
+import { getMyUserData } from "../../WebAPI";
+import { getAuthToken } from "../../utils";
 import TeacherManagePage from "../../pages/TeacherManagePage";
 import TeacherProfilePage from "../../pages/TeacherProfilePage";
 import HomePage from "../../pages/HomePage";
@@ -10,31 +14,47 @@ import TeacherCalendarPage from "../../pages/TeacherCalendarPage";
 import FilterPage from "../../pages/FilterPage";
 
 function App() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const token = getAuthToken();
+    if (!token) {
+      return;
+    }
+    getMyUserData().then((response) => {
+      if (response.success === true) {
+        setUser(response.user);
+      }
+    });
+  });
+
   return (
-    <Router>
-      <>
-        <Nav />
-        <Routes>
-          <Route exact path="/login" element={<LoginPage />}></Route>
-          <Route exact path="/register" element={<RegisterPage />}></Route>
-          <Route exact path="/" element={<HomePage />}></Route>
-          <Route exact path="/filter" element={<FilterPage />}></Route>
-          <Route
-            path="/teacher/manage/:teacherId"
-            element={<TeacherManagePage />}
-          />
-          <Route
-            path="/teacher/profile/:teacherId"
-            element={<TeacherProfilePage />}
-          />
-          <Route
-            path="/teacher/calendar/:teacherId"
-            element={<TeacherCalendarPage />}
-          />
-        </Routes>
-        <Footer />
-      </>
-    </Router>
+    <AuthContext.Provider value={{ user, setUser }}>
+      <Router>
+        <>
+          <Nav />
+          <Routes>
+            <Route exact path="/login" element={<LoginPage />}></Route>
+            <Route exact path="/register" element={<RegisterPage />}></Route>
+            <Route exact path="/" element={<HomePage />}></Route>
+            <Route exact path="/filter" element={<FilterPage />}></Route>
+            <Route
+              path="/teacher/manage/:teacherId"
+              element={<TeacherManagePage />}
+            />
+            <Route
+              path="/teacher/profile/:teacherId"
+              element={<TeacherProfilePage />}
+            />
+            <Route
+              path="/teacher/calendar/:teacherId"
+              element={<TeacherCalendarPage />}
+            />
+          </Routes>
+          <Footer />
+        </>
+      </Router>
+    </AuthContext.Provider>
   );
 }
 

--- a/skilfor/src/components/LoginRegisterForm/LoginRegisterFormItem.js
+++ b/skilfor/src/components/LoginRegisterForm/LoginRegisterFormItem.js
@@ -1,0 +1,108 @@
+import styled from "styled-components";
+import { MEDIA_QUERY_SM } from "../constants/breakpoints";
+import { Link } from "react-router-dom";
+
+export const FormItemContainer = styled.div`
+  margin: 5px 0;
+  padding: 10px 0 0;
+  width: 80%;
+  height: 80px;
+  ${MEDIA_QUERY_SM} {
+    height: 66px;
+  }
+`;
+
+export const ItemName = styled.h1`
+  color: ${(props) => props.theme.colors.grey_dark};
+  font-size: 1.4rem;
+  margin: 5px 0;
+  position: relative;
+  ${MEDIA_QUERY_SM} {
+    font-size: 1.3rem;
+    margin: 2px 0;
+  }
+`;
+
+const ForgetPassword = styled(Link)`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  font-size: 1.2rem;
+  text-decoration: none;
+  ${MEDIA_QUERY_SM} {
+    font-size: 1rem;
+  }
+`;
+
+const ItemLabel = styled.label`
+  width: 50%;
+  cursor: pointer;
+  font-size: 1.3rem;
+  padding: 10px;
+  float: left;
+  ${MEDIA_QUERY_SM} {
+    padding: 2px;
+    font-size: 1rem;
+  }
+`;
+
+const ItemInput = styled.input`
+  height: 30px;
+  padding: 5px;
+  width: 100%;
+  color: ${(props) => props.theme.colors.grey_dark};
+  font-size: 1rem;
+  border: none;
+  border-bottom: 1px solid ${(props) => props.theme.colors.grey_light};
+  ${MEDIA_QUERY_SM} {
+    height: 20px;
+  }
+`;
+
+const ItemRadioInput = styled(ItemInput)`
+  height: 30px;
+  width: 50%;
+  zoom: 0.6;
+  ${MEDIA_QUERY_SM} {
+    width: 20%;
+    margin-right: 8px;
+  }
+`;
+
+export function FormItem({ itemName, id, value, type, handleChange }) {
+  return (
+    <>
+      <FormItemContainer>
+        <ItemName>
+          {itemName}
+          {id === "password" && (
+            <ForgetPassword to="./reset_password">忘記密碼</ForgetPassword>
+          )}
+        </ItemName>
+        <ItemInput id={id} value={value} type={type} onChange={handleChange} />
+      </FormItemContainer>
+    </>
+  );
+}
+
+export function RadioFormItem({
+  radioItemName,
+  value,
+  id,
+  type,
+  name,
+  handleClick,
+}) {
+  return (
+    <ItemLabel>
+      <ItemRadioInput
+        value={value}
+        id={id}
+        type={type}
+        name={name}
+        onClick={handleClick}
+      />
+      {radioItemName}
+    </ItemLabel>
+  );
+}

--- a/skilfor/src/components/LoginRegisterForm/LoginRegisterFormWrapperStyle.js
+++ b/skilfor/src/components/LoginRegisterForm/LoginRegisterFormWrapperStyle.js
@@ -1,0 +1,90 @@
+import styled from "styled-components";
+import { MEDIA_QUERY_SM } from "../constants/breakpoints";
+
+const Wrapper = styled.div`
+  background: linear-gradient(
+    to right,
+    ${(props) => props.theme.colors.orange},
+    transparent 10%,
+    white 20%
+  );
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  ${MEDIA_QUERY_SM} {
+    max-width: 768px;
+  }
+`;
+
+const Container = styled.div`
+  padding: 120px 100px 200px 100px;
+  width: 700px;
+  height: 100%;
+  min-height: 1000px;
+  ${MEDIA_QUERY_SM} {
+    max-width: 500px;
+    padding: 120px 50px 200px 50px;
+  }
+`;
+
+const Title = styled.h1`
+  padding: 6px 0px 10px;
+  margin-bottom: 10px;
+  font-size: 1.5rem;
+  text-align: center;
+  color: ${(props) => props.theme.colors.grey_dark};
+  ${MEDIA_QUERY_SM} {
+    font-size: 1.4rem;
+  }
+`;
+
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  min-height: 300px;
+  border: 1px solid ${(props) => props.theme.colors.grey_light};
+  border-radius: 10px;
+  padding: 15px 40px;
+  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+  ${MEDIA_QUERY_SM} {
+    padding: 15px;
+  }
+`;
+
+const Btn = styled.button`
+  border-radius: 40px;
+  border: none;
+  cursor: pointer;
+  background-color: ${(props) => props.theme.colors.green_dark};
+  color: white;
+  font-weight: bold;
+  padding: 20px;
+  margin: 10px 0px 0px;
+  min-width: 150px;
+  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
+  font-size: 1.3rem;
+  :hover {
+    opacity: 0.7;
+  }
+
+  ${MEDIA_QUERY_SM} {
+    padding: 10px;
+    min-width: 80px;
+    font-size: 1rem;
+  }
+`;
+
+const ErrorMessage = styled.span`
+  color: red;
+  font-weight: bold;
+  font-size: 1.4rem;
+  ${MEDIA_QUERY_SM} {
+    font-size: 1rem;
+  }
+`;
+
+export { Wrapper, Container, Title, FormContainer, Btn, ErrorMessage };

--- a/skilfor/src/components/LoginRegisterForm/useLogin.js
+++ b/skilfor/src/components/LoginRegisterForm/useLogin.js
@@ -1,0 +1,92 @@
+import { useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { login, getMyUserData } from "../../WebAPI";
+import { setAuthToken } from "../../utils";
+import { AuthContext } from "../../contexts";
+
+export default function useLogin() {
+  const { setUser, setIsLoading } = useContext(AuthContext);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [identity, setIdentity] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const navigate = useNavigate();
+
+  const handleLogin = (e) => {
+    setIsLoading(true);
+    setErrorMessage("");
+    e.preventDefault();
+
+    if (email === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入Email");
+    } else if (password === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入密碼");
+    } else if (identity === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請選擇身分");
+    }
+
+    login(identity, email, password).then((data) => {
+      if (!data) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage("伺服器維修中");
+      }
+      if (data.success === false) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage(data.errMessage);
+      }
+      setAuthToken(data.token);
+      getMyUserData().then((response) => {
+        if (response.success === false) {
+          setAuthToken("");
+          setIsLoading(false);
+          scrollTop();
+          return setErrorMessage(response.errMessage);
+        }
+        setUser(response.user);
+        setIsLoading(false);
+        navigate("/");
+      });
+    });
+  };
+
+  const scrollTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  const handleEmailChange = (e) => {
+    setErrorMessage("");
+    setEmail(e.target.value);
+  };
+
+  const handlePasswordChange = (e) => {
+    setErrorMessage("");
+    setPassword(e.target.value);
+  };
+
+  const handleIdentityToggle = (e) => {
+    setErrorMessage("");
+    setIdentity(e.target.value);
+  };
+
+  return {
+    email,
+    password,
+    identity,
+    errorMessage,
+    handleLogin,
+    handleEmailChange,
+    handlePasswordChange,
+    handleIdentityToggle,
+  };
+}

--- a/skilfor/src/components/LoginRegisterForm/useRegister.js
+++ b/skilfor/src/components/LoginRegisterForm/useRegister.js
@@ -1,0 +1,139 @@
+import { useState, useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { register } from "../../WebAPI";
+import { setAuthToken } from "../../utils";
+import { getMyUserData } from "../../WebAPI";
+import { AuthContext } from "../../contexts";
+
+export default function useRegister() {
+  const { setUser, setIsLoading } = useContext(AuthContext);
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [identity, setIdentity] = useState("");
+  const [password, setPassword] = useState("");
+  const [checkPassword, setCheckPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const navigate = useNavigate();
+
+  const handleRegister = (e) => {
+    setIsLoading(true);
+    setErrorMessage("");
+    e.preventDefault();
+
+    if (username === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入使用者名稱");
+    } else if (identity === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請選擇註冊身分");
+    } else if (email === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入Email");
+    } else if (contactEmail === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入聯絡用Email");
+    } else if (password === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入密碼");
+    } else if (checkPassword === "") {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請再次輸入密碼");
+    } else if (password !== checkPassword) {
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("密碼不相同");
+    }
+
+    register(
+      username,
+      identity,
+      email,
+      contactEmail,
+      password,
+      checkPassword
+    ).then((data) => {
+      if (!data) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage("伺服器維修中");
+      }
+      if (data.success === false) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage(data.errMessage);
+      }
+      setAuthToken(data.token);
+      getMyUserData().then((response) => {
+        if (response.success === false) {
+          setIsLoading(false);
+          scrollTop();
+          return setErrorMessage(response.errMessage);
+        }
+        setUser(response.user);
+        setIsLoading(false);
+        navigate("/");
+      });
+    });
+  };
+
+  const scrollTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  const handleUsernameChange = (e) => {
+    setErrorMessage("");
+    setUsername(e.target.value);
+  };
+
+  const handleEmailChange = (e) => {
+    setErrorMessage("");
+    setEmail(e.target.value);
+  };
+
+  const handleContactEmailChange = (e) => {
+    setErrorMessage("");
+    setContactEmail(e.target.value);
+  };
+
+  const handleIdentityToggle = (e) => {
+    setErrorMessage("");
+    setIdentity(e.target.value);
+  };
+
+  const handlePasswordChange = (e) => {
+    setErrorMessage("");
+    setPassword(e.target.value);
+  };
+
+  const handleCheckPasswordChange = (e) => {
+    setErrorMessage("");
+    setCheckPassword(e.target.value);
+  };
+
+  return {
+    username,
+    email,
+    contactEmail,
+    identity,
+    password,
+    checkPassword,
+    errorMessage,
+    handleRegister,
+    handleUsernameChange,
+    handleEmailChange,
+    handleContactEmailChange,
+    handleIdentityToggle,
+    handlePasswordChange,
+    handleCheckPasswordChange,
+  };
+}

--- a/skilfor/src/contexts.js
+++ b/skilfor/src/contexts.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const AuthContext = createContext(null);

--- a/skilfor/src/pages/LoginPage/LoginPage.js
+++ b/skilfor/src/pages/LoginPage/LoginPage.js
@@ -1,7 +1,10 @@
 import styled from "styled-components";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useState, useContext } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { login, getMyUserData } from "../../WebAPI";
+import { setAuthToken } from "../../utils";
+import { AuthContext } from "../../contexts";
 
 const Wrapper = styled.div`
   background: linear-gradient(
@@ -157,10 +160,12 @@ const ErrorMessage = styled.span`
 `;
 
 function LoginPage() {
+  const { setUser } = useContext(AuthContext);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [identity, setIdentity] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const navigate = useNavigate();
 
   const handleSubmit = (e) => {
     setErrorMessage("");
@@ -173,6 +178,21 @@ function LoginPage() {
     } else if (identity === "") {
       setErrorMessage("請選擇身分");
     }
+
+    login(identity, email, password).then((data) => {
+      if (data.success === false) {
+        return setErrorMessage(data.errMessage);
+      }
+      setAuthToken(data.token);
+      getMyUserData().then((response) => {
+        if (response.success === false) {
+          setAuthToken("");
+          return setErrorMessage(response.errMessage);
+        }
+        setUser(response.user);
+        navigate("/");
+      });
+    });
   };
 
   const handleEmailChange = (e) => {

--- a/skilfor/src/pages/LoginPage/LoginPage.js
+++ b/skilfor/src/pages/LoginPage/LoginPage.js
@@ -160,7 +160,7 @@ const ErrorMessage = styled.span`
 `;
 
 function LoginPage() {
-  const { setUser } = useContext(AuthContext);
+  const { setUser, setIsLoading } = useContext(AuthContext);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [identity, setIdentity] = useState("");
@@ -168,30 +168,54 @@ function LoginPage() {
   const navigate = useNavigate();
 
   const handleSubmit = (e) => {
+    setIsLoading(true);
     setErrorMessage("");
     e.preventDefault();
 
     if (email === "") {
-      setErrorMessage("請輸入Email");
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入Email");
     } else if (password === "") {
-      setErrorMessage("請輸入密碼");
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請輸入密碼");
     } else if (identity === "") {
-      setErrorMessage("請選擇身分");
+      setIsLoading(false);
+      scrollTop();
+      return setErrorMessage("請選擇身分");
     }
 
     login(identity, email, password).then((data) => {
+      if (!data) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage("伺服器維修中");
+      }
       if (data.success === false) {
+        setIsLoading(false);
+        scrollTop();
         return setErrorMessage(data.errMessage);
       }
       setAuthToken(data.token);
       getMyUserData().then((response) => {
         if (response.success === false) {
           setAuthToken("");
+          setIsLoading(false);
+          scrollTop();
           return setErrorMessage(response.errMessage);
         }
         setUser(response.user);
+        setIsLoading(false);
         navigate("/");
       });
+    });
+  };
+
+  const scrollTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
     });
   };
 

--- a/skilfor/src/pages/LoginPage/LoginPage.js
+++ b/skilfor/src/pages/LoginPage/LoginPage.js
@@ -1,285 +1,69 @@
-import styled from "styled-components";
-import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
-import { useState, useContext } from "react";
-import { Link, useNavigate } from "react-router-dom";
-import { login, getMyUserData } from "../../WebAPI";
-import { setAuthToken } from "../../utils";
-import { AuthContext } from "../../contexts";
-
-const Wrapper = styled.div`
-  background: linear-gradient(
-    to right,
-    ${(props) => props.theme.colors.orange},
-    transparent 10%,
-    white 20%
-  );
-  margin: 0 auto;
-  display: flex;
-  justify-content: center;
-  height: 100%;
-  ${MEDIA_QUERY_SM} {
-    max-width: 768px;
-  }
-`;
-
-const Container = styled.div`
-  padding: 120px 100px 200px 100px;
-  width: 700px;
-  height: 100%;
-  min-height: 1000px;
-  ${MEDIA_QUERY_SM} {
-    max-width: 500px;
-    padding: 120px 50px 200px 50px;
-  }
-`;
-
-const Title = styled.h1`
-  padding: 6px 0px 10px;
-  margin-bottom: 10px;
-  font-size: 1.7rem;
-  text-align: center;
-  color: ${(props) => props.theme.colors.grey_dark};
-  ${MEDIA_QUERY_SM} {
-    font-size: 1.4rem;
-  }
-`;
-
-const FormContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  width: 100%;
-  min-height: 300px;
-  border: 1px solid ${(props) => props.theme.colors.grey_light};
-  border-radius: 10px;
-  padding: 15px 40px;
-  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
-  ${MEDIA_QUERY_SM} {
-    padding: 15px;
-  }
-`;
-
-const FormItemContainer = styled.div`
-  margin: 5px 0;
-  padding: 10px 0 0;
-  width: 80%;
-  height: 100px;
-  ${MEDIA_QUERY_SM} {
-    height: 66px;
-  }
-`;
-
-const ItemName = styled.h1`
-  color: ${(props) => props.theme.colors.grey_dark};
-  font-size: 1.6rem;
-  margin: 5px 0;
-  position: relative;
-  ${MEDIA_QUERY_SM} {
-    font-size: 1.3rem;
-    margin: 2px 0;
-  }
-`;
-
-const ForgetPassword = styled(Link)`
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  font-size: 1.2rem;
-  text-decoration: none;
-  ${MEDIA_QUERY_SM} {
-    font-size: 1rem;
-  }
-`;
-
-const ItemLabel = styled.label`
-  margin: 10px 0px;
-  width: 50%;
-  cursor: pointer;
-  font-size: 1.4rem;
-  padding: 10px;
-  float: left;
-  ${MEDIA_QUERY_SM} {
-    padding: 2px;
-    font-size: 1rem;
-  }
-`;
-
-const ItemInput = styled.input`
-  height: 30px;
-  padding: 5px;
-  width: 100%;
-  color: ${(props) => props.theme.colors.grey_dark};
-  font-size: 1rem;
-  border: none;
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey_light};
-  ${MEDIA_QUERY_SM} {
-    height: 20px;
-  }
-`;
-
-const ItemRadioInput = styled(ItemInput)`
-  height: 30px;
-  width: 50%;
-  zoom: 0.6;
-  ${MEDIA_QUERY_SM} {
-    width: 20%;
-    margin-right: 8px;
-  }
-`;
-
-const Btn = styled.button`
-  border-radius: 40px;
-  border: none;
-  cursor: pointer;
-  background-color: ${(props) => props.theme.colors.green_dark};
-  color: white;
-  font-weight: bold;
-  padding: 20px;
-  margin: 10px 0px 0px;
-  min-width: 150px;
-  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
-
-  :hover {
-    opacity: 0.7;
-  }
-
-  ${MEDIA_QUERY_SM} {
-    padding: 10px;
-    min-width: 80px;
-  }
-`;
-
-const ErrorMessage = styled.span`
-  color: red;
-  font-weight: bold;
-  font-size: 1.5rem;
-  ${MEDIA_QUERY_SM} {
-    font-size: 1rem;
-  }
-`;
+import {
+  FormItem,
+  RadioFormItem,
+  FormItemContainer,
+  ItemName,
+} from "../../components/LoginRegisterForm/LoginRegisterFormItem";
+import {
+  Wrapper,
+  Container,
+  Title,
+  FormContainer,
+  Btn,
+  ErrorMessage,
+} from "../../components/LoginRegisterForm/LoginRegisterFormWrapperStyle";
+import useLogin from "../../components/LoginRegisterForm/useLogin";
 
 function LoginPage() {
-  const { setUser, setIsLoading } = useContext(AuthContext);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [identity, setIdentity] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  const navigate = useNavigate();
-
-  const handleSubmit = (e) => {
-    setIsLoading(true);
-    setErrorMessage("");
-    e.preventDefault();
-
-    if (email === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入Email");
-    } else if (password === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入密碼");
-    } else if (identity === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請選擇身分");
-    }
-
-    login(identity, email, password).then((data) => {
-      if (!data) {
-        setIsLoading(false);
-        scrollTop();
-        return setErrorMessage("伺服器維修中");
-      }
-      if (data.success === false) {
-        setIsLoading(false);
-        scrollTop();
-        return setErrorMessage(data.errMessage);
-      }
-      setAuthToken(data.token);
-      getMyUserData().then((response) => {
-        if (response.success === false) {
-          setAuthToken("");
-          setIsLoading(false);
-          scrollTop();
-          return setErrorMessage(response.errMessage);
-        }
-        setUser(response.user);
-        setIsLoading(false);
-        navigate("/");
-      });
-    });
-  };
-
-  const scrollTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  };
-
-  const handleEmailChange = (e) => {
-    setErrorMessage("");
-    setEmail(e.target.value);
-  };
-
-  const handlePasswordChange = (e) => {
-    setErrorMessage("");
-    setPassword(e.target.value);
-  };
-
-  const handleIdentityToggle = (e) => {
-    setErrorMessage("");
-    setIdentity(e.target.value);
-  };
+  const {
+    email,
+    password,
+    errorMessage,
+    handleLogin,
+    handleEmailChange,
+    handlePasswordChange,
+    handleIdentityToggle,
+  } = useLogin();
 
   return (
     <Wrapper>
       <Container>
         <Title>登入帳戶</Title>
-        <FormContainer onSubmit={handleSubmit}>
+        <FormContainer onSubmit={handleLogin}>
           {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-          <FormItemContainer>
-            <ItemName>Email</ItemName>
-            <ItemInput
-              value={email}
-              type="email"
-              onChange={handleEmailChange}
-            />
-          </FormItemContainer>
+          <FormItem
+            itemName="Email"
+            id="email"
+            value={email}
+            type="email"
+            handleChange={handleEmailChange}
+          />
           <FormItemContainer>
             <ItemName>登入身分</ItemName>
-            <ItemLabel>
-              <ItemRadioInput
-                value="student"
-                type="radio"
-                name="identity"
-                onClick={handleIdentityToggle}
-              />
-              學生
-            </ItemLabel>
-            <ItemLabel>
-              <ItemRadioInput
-                value="teacher"
-                type="radio"
-                name="identity"
-                onClick={handleIdentityToggle}
-              />
-              老師
-            </ItemLabel>
-          </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>
-              密碼
-              <ForgetPassword to="./reset_password">忘記密碼</ForgetPassword>
-            </ItemName>
-            <ItemInput
-              value={password}
-              type="password"
-              onChange={handlePasswordChange}
+            <RadioFormItem
+              radioItemName="學生"
+              id="student"
+              value="student"
+              type="radio"
+              name="identity"
+              handleClick={handleIdentityToggle}
+            />
+            <RadioFormItem
+              radioItemName="老師"
+              id="teacher"
+              value="teacher"
+              type="radio"
+              name="identity"
+              handleClick={handleIdentityToggle}
             />
           </FormItemContainer>
+          <FormItem
+            itemName="密碼"
+            id="password"
+            value={password}
+            type="password"
+            handleChange={handlePasswordChange}
+          />
           <Btn>登入</Btn>
         </FormContainer>
       </Container>

--- a/skilfor/src/pages/RegisterPage/RegisterPage.js
+++ b/skilfor/src/pages/RegisterPage/RegisterPage.js
@@ -150,7 +150,7 @@ const ErrorMessage = styled.span`
 `;
 
 function RegisterPage() {
-  const { setUser } = useContext(AuthContext);
+  const { setUser, setIsLoading } = useContext(AuthContext);
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [contactEmail, setContactEmail] = useState("");
@@ -161,32 +161,38 @@ function RegisterPage() {
   const navigate = useNavigate();
 
   const handleSubmit = (e) => {
+    setIsLoading(true);
     setErrorMessage("");
     e.preventDefault();
 
     if (username === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請輸入使用者名稱");
+      return setErrorMessage("請輸入使用者名稱");
     } else if (identity === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請選擇註冊身分");
+      return setErrorMessage("請選擇註冊身分");
     } else if (email === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請輸入Email");
+      return setErrorMessage("請輸入Email");
     } else if (contactEmail === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請輸入聯絡用Email");
+      return setErrorMessage("請輸入聯絡用Email");
     } else if (password === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請輸入密碼");
+      return setErrorMessage("請輸入密碼");
     } else if (checkPassword === "") {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("請再次輸入密碼");
+      return setErrorMessage("請再次輸入密碼");
     } else if (password !== checkPassword) {
+      setIsLoading(false);
       scrollTop();
-      setErrorMessage("密碼不相同");
-    } else {
-      navigate("/");
+      return setErrorMessage("密碼不相同");
     }
 
     register(
@@ -197,15 +203,25 @@ function RegisterPage() {
       password,
       checkPassword
     ).then((data) => {
+      if (!data) {
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage("伺服器維修中");
+      }
       if (data.success === false) {
-        return setErrorMessage(data.ErrMessage);
+        setIsLoading(false);
+        scrollTop();
+        return setErrorMessage(data.errMessage);
       }
       setAuthToken(data.token);
       getMyUserData().then((response) => {
         if (response.success === false) {
-          return setErrorMessage(response.ErrMessage);
+          setIsLoading(false);
+          scrollTop();
+          return setErrorMessage(response.errMessage);
         }
         setUser(response.user);
+        setIsLoading(false);
         navigate("/");
       });
     });
@@ -284,7 +300,7 @@ function RegisterPage() {
             </ItemLabel>
           </FormItemContainer>
           <FormItemContainer>
-            <ItemName>Email</ItemName>
+            <ItemName>登入用 Email</ItemName>
             <ItemInput
               value={email}
               type="email"

--- a/skilfor/src/pages/RegisterPage/RegisterPage.js
+++ b/skilfor/src/pages/RegisterPage/RegisterPage.js
@@ -1,7 +1,11 @@
 import styled from "styled-components";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
+import { register } from "../../WebAPI";
+import { setAuthToken } from "../../utils";
+import { getMyUserData } from "../../WebAPI";
+import { AuthContext } from "../../contexts";
 
 const Wrapper = styled.div`
   background: linear-gradient(
@@ -146,6 +150,7 @@ const ErrorMessage = styled.span`
 `;
 
 function RegisterPage() {
+  const { setUser } = useContext(AuthContext);
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [contactEmail, setContactEmail] = useState("");
@@ -183,6 +188,27 @@ function RegisterPage() {
     } else {
       navigate("/");
     }
+
+    register(
+      username,
+      identity,
+      email,
+      contactEmail,
+      password,
+      checkPassword
+    ).then((data) => {
+      if (data.success === false) {
+        return setErrorMessage(data.ErrMessage);
+      }
+      setAuthToken(data.token);
+      getMyUserData().then((response) => {
+        if (response.success === false) {
+          return setErrorMessage(response.ErrMessage);
+        }
+        setUser(response.user);
+        navigate("/");
+      });
+    });
   };
 
   const scrollTop = () => {

--- a/skilfor/src/pages/RegisterPage/RegisterPage.js
+++ b/skilfor/src/pages/RegisterPage/RegisterPage.js
@@ -1,336 +1,93 @@
-import styled from "styled-components";
-import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
-import { useState, useContext } from "react";
-import { useNavigate } from "react-router-dom";
-import { register } from "../../WebAPI";
-import { setAuthToken } from "../../utils";
-import { getMyUserData } from "../../WebAPI";
-import { AuthContext } from "../../contexts";
-
-const Wrapper = styled.div`
-  background: linear-gradient(
-    to right,
-    ${(props) => props.theme.colors.orange},
-    transparent 10%,
-    white 20%
-  );
-  margin: 0 auto;
-  display: flex;
-  justify-content: center;
-  height: 100%;
-  ${MEDIA_QUERY_SM} {
-    max-width: 768px;
-  }
-`;
-
-const Container = styled.div`
-  padding: 120px 100px 200px 100px;
-  width: 700px;
-  height: 100%;
-  min-height: 1000px;
-  ${MEDIA_QUERY_SM} {
-    max-width: 500px;
-    padding: 120px 50px 200px 50px;
-  }
-`;
-
-const Title = styled.h1`
-  padding: 6px 0px 10px;
-  margin-bottom: 10px;
-  font-size: 1.7rem;
-  text-align: center;
-  color: ${(props) => props.theme.colors.grey_dark};
-  ${MEDIA_QUERY_SM} {
-    font-size: 1.4rem;
-  }
-`;
-
-const FormContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
-  width: 100%;
-  min-height: 300px;
-  border: 1px solid ${(props) => props.theme.colors.grey_light};
-  border-radius: 10px;
-  padding: 15px 40px;
-  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
-  ${MEDIA_QUERY_SM} {
-    padding: 15px;
-  }
-`;
-
-const FormItemContainer = styled.div`
-  margin: 5px 0;
-  padding: 10px 0 0;
-  width: 80%;
-  height: 100px;
-  ${MEDIA_QUERY_SM} {
-    height: 66px;
-  }
-`;
-
-const ItemName = styled.h1`
-  color: ${(props) => props.theme.colors.grey_dark};
-  font-size: 1.6rem;
-  margin: 5px 0;
-  position: relative;
-  ${MEDIA_QUERY_SM} {
-    font-size: 1.3rem;
-    margin: 2px 0;
-  }
-`;
-
-const ItemLabel = styled.label`
-  margin: 10px 0px;
-  width: 50%;
-  cursor: pointer;
-  font-size: 1.4rem;
-  padding: 10px;
-  float: left;
-  ${MEDIA_QUERY_SM} {
-    padding: 2px;
-    font-size: 1rem;
-  }
-`;
-
-const ItemInput = styled.input`
-  height: 30px;
-  padding: 5px;
-  width: 100%;
-  color: ${(props) => props.theme.colors.grey_dark};
-  font-size: 1rem;
-  border: none;
-  border-bottom: 1px solid ${(props) => props.theme.colors.grey_light};
-  ${MEDIA_QUERY_SM} {
-    height: 20px;
-  }
-`;
-
-const ItemRadioInput = styled(ItemInput)`
-  height: 30px;
-  width: 50%;
-  zoom: 0.6;
-  ${MEDIA_QUERY_SM} {
-    width: 20%;
-    margin-right: 8px;
-  }
-`;
-
-const Btn = styled.button`
-  border-radius: 40px;
-  border: none;
-  cursor: pointer;
-  background-color: ${(props) => props.theme.colors.green_dark};
-  color: white;
-  font-weight: bold;
-  padding: 20px;
-  margin: 10px 0px 0px;
-  min-width: 150px;
-  box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
-
-  :hover {
-    opacity: 0.7;
-  }
-
-  ${MEDIA_QUERY_SM} {
-    padding: 10px;
-    min-width: 80px;
-  }
-`;
-
-const ErrorMessage = styled.span`
-  color: red;
-  font-weight: bold;
-  font-size: 1.5rem;
-  ${MEDIA_QUERY_SM} {
-    font-size: 1rem;
-  }
-`;
+import {
+  FormItem,
+  RadioFormItem,
+  FormItemContainer,
+  ItemName,
+} from "../../components/LoginRegisterForm/LoginRegisterFormItem";
+import {
+  Wrapper,
+  Container,
+  Title,
+  FormContainer,
+  Btn,
+  ErrorMessage,
+} from "../../components/LoginRegisterForm/LoginRegisterFormWrapperStyle";
+import useRegister from "../../components/LoginRegisterForm/useRegister";
 
 function RegisterPage() {
-  const { setUser, setIsLoading } = useContext(AuthContext);
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
-  const [contactEmail, setContactEmail] = useState("");
-  const [identity, setIdentity] = useState("");
-  const [password, setPassword] = useState("");
-  const [checkPassword, setCheckPassword] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  const navigate = useNavigate();
-
-  const handleSubmit = (e) => {
-    setIsLoading(true);
-    setErrorMessage("");
-    e.preventDefault();
-
-    if (username === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入使用者名稱");
-    } else if (identity === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請選擇註冊身分");
-    } else if (email === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入Email");
-    } else if (contactEmail === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入聯絡用Email");
-    } else if (password === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請輸入密碼");
-    } else if (checkPassword === "") {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("請再次輸入密碼");
-    } else if (password !== checkPassword) {
-      setIsLoading(false);
-      scrollTop();
-      return setErrorMessage("密碼不相同");
-    }
-
-    register(
-      username,
-      identity,
-      email,
-      contactEmail,
-      password,
-      checkPassword
-    ).then((data) => {
-      if (!data) {
-        setIsLoading(false);
-        scrollTop();
-        return setErrorMessage("伺服器維修中");
-      }
-      if (data.success === false) {
-        setIsLoading(false);
-        scrollTop();
-        return setErrorMessage(data.errMessage);
-      }
-      setAuthToken(data.token);
-      getMyUserData().then((response) => {
-        if (response.success === false) {
-          setIsLoading(false);
-          scrollTop();
-          return setErrorMessage(response.errMessage);
-        }
-        setUser(response.user);
-        setIsLoading(false);
-        navigate("/");
-      });
-    });
-  };
-
-  const scrollTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  };
-
-  const handleUsernameChange = (e) => {
-    setErrorMessage("");
-    setUsername(e.target.value);
-  };
-
-  const handleEmailChange = (e) => {
-    setErrorMessage("");
-    setEmail(e.target.value);
-  };
-
-  const handleContactEmailChange = (e) => {
-    setErrorMessage("");
-    setContactEmail(e.target.value);
-  };
-
-  const handleIdentityToggle = (e) => {
-    setErrorMessage("");
-    setIdentity(e.target.value);
-  };
-
-  const handlePasswordChange = (e) => {
-    setErrorMessage("");
-    setPassword(e.target.value);
-  };
-
-  const handleCheckPasswordChange = (e) => {
-    setErrorMessage("");
-    setCheckPassword(e.target.value);
-  };
-
+  const {
+    username,
+    email,
+    contactEmail,
+    password,
+    checkPassword,
+    errorMessage,
+    handleRegister,
+    handleUsernameChange,
+    handleEmailChange,
+    handleContactEmailChange,
+    handleIdentityToggle,
+    handlePasswordChange,
+    handleCheckPasswordChange,
+  } = useRegister();
   return (
     <Wrapper>
       <Container>
         <Title>註冊帳戶</Title>
-        <FormContainer onSubmit={handleSubmit}>
+        <FormContainer onSubmit={handleRegister}>
           {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+          <FormItem
+            itemName="使用者名稱"
+            id="username"
+            value={username}
+            type="text"
+            handleChange={handleUsernameChange}
+          />
           <FormItemContainer>
-            <ItemName>使用者名稱</ItemName>
-            <ItemInput
-              value={username}
-              type="text"
-              onChange={handleUsernameChange}
+            <ItemName>登入身分</ItemName>
+            <RadioFormItem
+              radioItemName="學生"
+              value="student"
+              type="radio"
+              name="identity"
+              handleClick={handleIdentityToggle}
+            />
+            <RadioFormItem
+              radioItemName="老師"
+              value="teacher"
+              type="radio"
+              name="identity"
+              handleClick={handleIdentityToggle}
             />
           </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>身分</ItemName>
-            <ItemLabel>
-              <ItemRadioInput
-                value="student"
-                type="radio"
-                name="identity"
-                onClick={handleIdentityToggle}
-              />
-              學生
-            </ItemLabel>
-            <ItemLabel>
-              <ItemRadioInput
-                value="teacher"
-                type="radio"
-                name="identity"
-                onClick={handleIdentityToggle}
-              />
-              老師
-            </ItemLabel>
-          </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>登入用 Email</ItemName>
-            <ItemInput
-              value={email}
-              type="email"
-              onChange={handleEmailChange}
-            />
-          </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>聯絡用 Email</ItemName>
-            <ItemInput
-              value={contactEmail}
-              type="email"
-              onChange={handleContactEmailChange}
-            />
-          </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>密碼</ItemName>
-            <ItemInput
-              value={password}
-              type="password"
-              onChange={handlePasswordChange}
-            />
-          </FormItemContainer>
-          <FormItemContainer>
-            <ItemName>再次確認密碼</ItemName>
-            <ItemInput
-              value={checkPassword}
-              type="password"
-              onChange={handleCheckPasswordChange}
-            />
-          </FormItemContainer>
+          <FormItem
+            itemName="登入用 Email"
+            id="email"
+            value={email}
+            type="email"
+            handleChange={handleEmailChange}
+          />
+          <FormItem
+            itemName="聯絡用 Email"
+            id="contactEmail"
+            value={contactEmail}
+            type="email"
+            handleChange={handleContactEmailChange}
+          />
+          <FormItem
+            itemName="密碼"
+            id="password"
+            value={password}
+            type="password"
+            handleChange={handlePasswordChange}
+          />
+          <FormItem
+            itemName="再次確認密碼"
+            id="checkPassword"
+            value={checkPassword}
+            type="password"
+            handleChange={handleCheckPasswordChange}
+          />
           <Btn>註冊</Btn>
         </FormContainer>
       </Container>

--- a/skilfor/src/utils.js
+++ b/skilfor/src/utils.js
@@ -1,3 +1,13 @@
 export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+const TOKEN_NAME = "token";
+
+export const setAuthToken = (token) => {
+  localStorage.setItem(TOKEN_NAME, token);
+};
+
+export const getAuthToken = () => {
+  localStorage.getItem(TOKEN_NAME);
+};


### PR DESCRIPTION
**主要**
1. 重構登入與註冊頁面
- 把 `FormItem` 抽出來當 component 放進 LoginRegisterFormItem 檔案
- 把兩頁面的最外層 style 抽出來寫進 LoginRegisterFormWrapperStyle 檔案 ，要改 style 的話兩個頁面會連動一起改比較好調整
- 功能方面切成兩個 hooks `useLogin()` 、`useRegister()`
2. 新增  WebAPI.js 檔案，加上 `login`、`register`、`getMyUserData` 三支 API 及錯誤處理，尚未測試有沒有串成功
3. 加入`useContext()`這個 hook，用來傳 User 資料跟 Loading 的功能

