### PR TITLE
重構老師後台的個人資訊與課程資訊頁面

### DIFF
--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -66,3 +66,39 @@ export const register = async (
     return console.log(error.message);
   }
 };
+
+export const getTeacherInfos = async (teacherId) => {
+  let url = `${BASE_URL}/teacher/${teacherId}/info`;
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) throw new Error("fail to fetch data");
+    return await res.json();
+  } catch (error) {
+    return error.message;
+  }
+};
+
+export const getTeacherCourseInfos = async (teacherId) => {
+  let url = `${BASE_URL}/teacher/${teacherId}/course/info`;
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) throw new Error("fail to fetch data");
+    return await res.json();
+  } catch (error) {
+    return error.message;
+  }
+};

--- a/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
@@ -30,7 +30,7 @@ const CategoryDropDownMenu = ({
   courseInfos,
   setCourseInfos,
   setSelectedCourseInfos,
-  setEditCourseContent,
+  setEditContent,
 }) => {
   const [selectOptions, setSelectOptions] = useState(null);
   const makeSelectOptions = useCallback((categoryArr, courseArr) => {
@@ -62,7 +62,7 @@ const CategoryDropDownMenu = ({
     };
     setCourseInfos([newCourseInfos, ...courseInfos]);
     setSelectedCourseInfos(newCourseInfos);
-    setEditCourseContent(newCourseInfos);
+    setEditContent(newCourseInfos);
   };
   return (
     <SelectContainer>

--- a/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
@@ -1,0 +1,91 @@
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import styled from "styled-components";
+import { CATEGORY_LIST } from "../Constant";
+import { sleep } from "../../../utils";
+
+const RowContainer = styled.div`
+  display: flex;
+`;
+const SelectContainer = styled(RowContainer)``;
+const SelectBar = styled.select`
+  padding: 5px;
+  font-size: 1rem;
+  border: 1px solid ${(props) => props.theme.colors.grey_dark};
+  color: ${(props) => props.theme.colors.grey_dark};
+`;
+const ChooseCategoryButton = styled.button`
+  border: 1px solid ${(props) => props.theme.colors.grey_dark};
+  padding: 8px;
+  font-size: 0.8rem;
+  border-left: none;
+  cursor: pointer;
+  background: ${(props) => props.theme.colors.grey_dark};
+  color: white;
+  :hover {
+    opacity: 0.85;
+  }
+`;
+
+const CategoryDropDownMenu = ({
+  courseInfos,
+  setCourseInfos,
+  setSelectedCourseInfos,
+  setEditCourseContent,
+}) => {
+  const [selectOptions, setSelectOptions] = useState(null);
+  const makeSelectOptions = useCallback((categoryArr, courseArr) => {
+    if (!categoryArr || !courseArr) return;
+    let temp = [];
+    for (let i = 0; i < courseArr.length; i++) {
+      temp.push(courseArr[i].category);
+    }
+    let result = categoryArr.filter((category) => !temp.includes(category));
+    return result;
+  }, []);
+  useEffect(() => {
+    async function fetchData() {
+      await sleep(100);
+      setSelectOptions(CATEGORY_LIST);
+    }
+    fetchData();
+  }, []);
+  const selectedCategory = useRef(null);
+  const handleSelectCategorySubmit = (e) => {
+    if (!selectedCategory.current.value) return;
+    let newCourseInfos = {
+      category: selectedCategory.current.value,
+      courseName: "",
+      courseIntro: "",
+      price: "",
+      audit: false,
+      published: false,
+    };
+    setCourseInfos([newCourseInfos, ...courseInfos]);
+    setSelectedCourseInfos(newCourseInfos);
+    setEditCourseContent(newCourseInfos);
+  };
+  return (
+    <SelectContainer>
+      <RowContainer>
+        <SelectBar id="addCategory" ref={selectedCategory}>
+          <option value="">請選擇一個課程領域</option>
+          {selectOptions &&
+            courseInfos &&
+            makeSelectOptions(selectOptions, courseInfos).map((category) => (
+              <option key={category}>{category}</option>
+            ))}
+          {courseInfos &&
+            courseInfos.length === 0 &&
+            selectOptions.map((category) => (
+              <option key={category}>{category}</option>
+            ))}
+        </SelectBar>
+        <ChooseCategoryButton onClick={handleSelectCategorySubmit}>
+          新增
+        </ChooseCategoryButton>
+      </RowContainer>
+    </SelectContainer>
+  );
+};
+
+export default CategoryDropDownMenu;

--- a/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
@@ -1,16 +1,22 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 import styled from "styled-components";
 import CourseInfosForm from "./CourseInfosForm";
 import happy from "../../../img/happy.png";
 import sad from "../../../img/sad.png";
 import { nanoid } from "nanoid";
-import { CATEGORY_LIST, COURSE_LIST } from "../Constant";
+import { COURSE_LIST } from "../Constant";
 import { sleep } from "../../../utils";
+import CategoryDropDownMenu from "./CategoryDropDownMenu";
+import {
+  EditContainer,
+  SectionText,
+  RowContainer,
+  EditButton,
+  SubmitButton,
+} from "./PageStyle";
+import PublishedRadiosContainer from "./PublishedRadiosContainer";
 
-export const RowContainer = styled.div`
-  display: flex;
-`;
 const ColumnContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -41,84 +47,9 @@ const PassText = styled.p`
       : props.theme.colors.warn};
   font-size: 1.1rem;
 `;
-const RadiosContainer = styled.form`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 20px;
-`;
-const RadioContainer = styled(RowContainer)`
-  align-items: center;
-  margin-bottom: 5px;
-`;
-const RadioInput = styled.input`
-  width: 20px;
-  height: 15px;
-`;
-
-const RadioLabel = styled.label`
-  color: ${(props) => props.theme.colors.grey_dark};
-  margin-left: 5px;
-`;
-const PublishedContainer = ({ handleRadioClick, published }) => {
-  return (
-    <RadiosContainer>
-      <RadioContainer>
-        <RadioInput
-          onClick={handleRadioClick}
-          name="published"
-          type="radio"
-          id="true"
-          defaultChecked={published}
-        />
-        <RadioLabel htmlFor="true">一切都 OK！發布至前台</RadioLabel>
-      </RadioContainer>
-      <RadioContainer>
-        <RadioInput
-          defaultChecked={!published}
-          onClick={handleRadioClick}
-          name="published"
-          type="radio"
-          id="false"
-        />
-        <RadioLabel htmlFor="false">還有資訊需要編輯，暫時不發布</RadioLabel>
-      </RadioContainer>
-    </RadiosContainer>
-  );
-};
-
-export const EditContainer = styled(RowContainer)`
-  justify-content: space-between;
-  align-items: baseline;
-  margin-top: 10px;
-`;
-
-export const EditButton = styled.button`
-  background: ${(props) => props.theme.colors.green_dark};
-  border: none;
-  color: white;
-  font-size: 1rem;
-  height: fit-content;
-  padding: 7px 14px;
-  cursor: pointer;
-  :hover {
-    opacity: 0.8;
-  }
-`;
-
-export const SubmitButton = styled(EditButton)`
-  margin-left: 15px;
-`;
-
 const DeleteButton = styled(EditButton)`
   margin-right: 15px;
 `;
-
-export const SectionText = styled.h3`
-  font-size: 1.3rem;
-  color: ${(props) => props.theme.colors.green_dark};
-  margin: 10px 0 20px 0;
-`;
-
 const CourseBtnsContainer = styled(RowContainer)`
   margin-bottom: 25px;
   align-items: center;
@@ -138,7 +69,6 @@ const CourseButton = styled.button`
     props.isClick &&
     `background: ${props.theme.colors.green_dark}; color:white; border:2px solid ${props.theme.colors.green_dark}`}
 `;
-
 const GoToCalendar = styled(Link)`
   color: ${(props) => props.theme.colors.grey_dark};
   cursor: pointer;
@@ -148,86 +78,6 @@ const GoToCalendar = styled(Link)`
     opacity: 0.8;
   }
 `;
-const SelectContainer = styled(RowContainer)``;
-const SelectBar = styled.select`
-  padding: 5px;
-  font-size: 1rem;
-  border: 1px solid ${(props) => props.theme.colors.grey_dark};
-  color: ${(props) => props.theme.colors.grey_dark};
-`;
-const ChooseCategoryButton = styled.button`
-  border: 1px solid ${(props) => props.theme.colors.grey_dark};
-  padding: 8px;
-  font-size: 0.8rem;
-  border-left: none;
-  cursor: pointer;
-  background: ${(props) => props.theme.colors.grey_dark};
-  color: white;
-  :hover {
-    opacity: 0.85;
-  }
-`;
-const SelectCategory = ({
-  courseInfos,
-  setCourseInfos,
-  setSelectedCourseInfos,
-  setEditCourseContent,
-}) => {
-  const [selectOptions, setSelectOptions] = useState(null);
-  const makeSelectOptions = useCallback((categoryArr, courseArr) => {
-    if (!categoryArr || !courseArr) return;
-    let temp = [];
-    for (let i = 0; i < courseArr.length; i++) {
-      temp.push(courseArr[i].category);
-    }
-    let result = categoryArr.filter((category) => !temp.includes(category));
-    return result;
-  }, []);
-  useEffect(() => {
-    async function fetchData() {
-      await sleep(100);
-      setSelectOptions(CATEGORY_LIST);
-    }
-    fetchData();
-  }, []);
-  const selectedCategory = useRef(null);
-  const handleSelectCategorySubmit = (e) => {
-    if (!selectedCategory.current.value) return;
-    let newCourseInfos = {
-      category: selectedCategory.current.value,
-      courseName: "",
-      courseIntro: "",
-      price: "",
-      audit: false,
-      published: false,
-    };
-    setCourseInfos([newCourseInfos, ...courseInfos]);
-    setSelectedCourseInfos(newCourseInfos);
-    setEditCourseContent(newCourseInfos);
-  };
-  return (
-    <SelectContainer>
-      <RowContainer>
-        <SelectBar id="addCategory" ref={selectedCategory}>
-          <option value="">請選擇一個課程領域</option>
-          {selectOptions &&
-            courseInfos &&
-            makeSelectOptions(selectOptions, courseInfos).map((category) => (
-              <option key={category}>{category}</option>
-            ))}
-          {courseInfos &&
-            courseInfos.length === 0 &&
-            selectOptions.map((category) => (
-              <option key={category}>{category}</option>
-            ))}
-        </SelectBar>
-        <ChooseCategoryButton onClick={handleSelectCategorySubmit}>
-          新增
-        </ChooseCategoryButton>
-      </RowContainer>
-    </SelectContainer>
-  );
-};
 
 function CoursePage() {
   const { teacherId } = useParams();
@@ -286,7 +136,7 @@ function CoursePage() {
         }
       })
     );
-    setSelectedCourseInfos(editCourseContent);
+    setSelectedCourseInfos(updatedCourseInfos);
     //將更改後的課程資訊 put 給後端
     console.log("PUT", updatedCourseInfos);
   };
@@ -331,7 +181,7 @@ function CoursePage() {
   return (
     <>
       <SectionText>新增課程</SectionText>
-      <SelectCategory
+      <CategoryDropDownMenu
         show={true}
         setCourseInfos={setCourseInfos}
         courseInfos={courseInfos}
@@ -431,7 +281,7 @@ function CoursePage() {
           {selectedCourseInfos.audit === "success" && (
             <>
               <SectionText>是否發布課程頁面</SectionText>
-              <PublishedContainer
+              <PublishedRadiosContainer
                 handleRadioClick={handleRadioClick}
                 published={selectedCourseInfos.published}
               />

--- a/skilfor/src/pages/TeacherManagePage/components/PageStyle.js
+++ b/skilfor/src/pages/TeacherManagePage/components/PageStyle.js
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+
+export const RowContainer = styled.div`
+  display: flex;
+`;
+
+export const SectionText = styled.h3`
+  font-size: 1.3rem;
+  color: ${(props) => props.theme.colors.green_dark};
+  margin: 10px 0 20px 0;
+`;
+
+export const EditContainer = styled(RowContainer)`
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 10px;
+`;
+
+export const EditButton = styled.button`
+  background: ${(props) => props.theme.colors.green_dark};
+  border: none;
+  color: white;
+  font-size: 1rem;
+  height: fit-content;
+  padding: 7px 14px;
+  cursor: pointer;
+  :hover {
+    opacity: 0.8;
+  }
+`;
+
+export const SubmitButton = styled(EditButton)`
+  margin-left: 15px;
+`;

--- a/skilfor/src/pages/TeacherManagePage/components/PublishedRadiosContainer.js
+++ b/skilfor/src/pages/TeacherManagePage/components/PublishedRadiosContainer.js
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+const RowContainer = styled.div`
+  display: flex;
+`;
+const RadiosContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
+`;
+const RadioContainer = styled(RowContainer)`
+  align-items: center;
+  margin-bottom: 5px;
+`;
+const RadioInput = styled.input`
+  width: 20px;
+  height: 15px;
+`;
+const RadioLabel = styled.label`
+  color: ${(props) => props.theme.colors.grey_dark};
+  margin-left: 5px;
+`;
+
+const PublishedRadiosContainer = ({ handleRadioClick, published }) => {
+  return (
+    <RadiosContainer>
+      <RadioContainer>
+        <RadioInput
+          onClick={handleRadioClick}
+          name="published"
+          type="radio"
+          id="true"
+          defaultChecked={published}
+        />
+        <RadioLabel htmlFor="true">一切都 OK！發布至前台</RadioLabel>
+      </RadioContainer>
+      <RadioContainer>
+        <RadioInput
+          defaultChecked={!published}
+          onClick={handleRadioClick}
+          name="published"
+          type="radio"
+          id="false"
+        />
+        <RadioLabel htmlFor="false">還有資訊需要編輯，暫時不發布</RadioLabel>
+      </RadioContainer>
+    </RadiosContainer>
+  );
+};
+
+export default PublishedRadiosContainer;

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -1,14 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { TEACHER_INFOS } from "../Constant";
 import { sleep } from "../../../utils";
-
 import {
   EditContainer,
   SectionText,
   RowContainer,
   EditButton,
   SubmitButton,
-} from "./CoursePage";
+} from "./PageStyle";
 import {
   FormItemContainer,
   ItemTop,

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -16,13 +16,17 @@ import {
   ItemValue,
   EditInput,
 } from "./CourseInfosForm";
+import useEdit from "../hooks/useEdit";
 
 function SelfPage() {
   const [teacherInfos, setTeacherInfos] = useState(null);
-  //個人資訊是否為編輯狀態
-  const [isEditingSelf, setIsEditingSelf] = useState(false);
-  //編輯個人資料內容
-  const [editSelfContent, setEditSelfContent] = useState(null);
+  const {
+    isEditingSelf,
+    setIsEditingSelf,
+    editSelfContent,
+    setEditSelfContent,
+    handleSelfEditClick,
+  } = useEdit();
   //拿取 teacher infos
   useEffect(() => {
     async function fetchData() {
@@ -34,14 +38,13 @@ function SelfPage() {
   //設定預設課程個人編輯 value
   useEffect(() => {
     setEditSelfContent(teacherInfos);
-  }, [teacherInfos]);
-  //編輯個人資訊按鈕被按時
-  const handleSelfEditClick = () => setIsEditingSelf(!isEditingSelf);
+  }, [teacherInfos, setEditSelfContent]);
   //完成編輯個人資訊按鈕被按時
   const handleSelfSubmitClick = () => {
     setIsEditingSelf(false);
-    //將更改後的課程資訊 post 給後端
     setTeacherInfos(editSelfContent);
+    //將更改後的課程資訊 post 給後端
+    console.log("PUT", editSelfContent);
   };
 
   const handleSelfInputChange = (e) => {

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -21,11 +21,11 @@ import useEdit from "../hooks/useEdit";
 function SelfPage() {
   const [teacherInfos, setTeacherInfos] = useState(null);
   const {
-    isEditingSelf,
-    setIsEditingSelf,
-    editSelfContent,
-    setEditSelfContent,
-    handleSelfEditClick,
+    isEditing,
+    setIsEditing,
+    editContent,
+    setEditContent,
+    handleEditClick,
   } = useEdit();
   //拿取 teacher infos
   useEffect(() => {
@@ -37,39 +37,38 @@ function SelfPage() {
   }, []);
   //設定預設課程個人編輯 value
   useEffect(() => {
-    setEditSelfContent(teacherInfos);
-  }, [teacherInfos, setEditSelfContent]);
+    setEditContent(teacherInfos);
+  }, [teacherInfos, setEditContent]);
   //完成編輯個人資訊按鈕被按時
   const handleSelfSubmitClick = () => {
-    setIsEditingSelf(false);
-    setTeacherInfos(editSelfContent);
+    setIsEditing(false);
+    setTeacherInfos(editContent);
     //將更改後的課程資訊 post 給後端
-    console.log("PUT", editSelfContent);
+    console.log("PUT", editContent);
   };
-
   const handleSelfInputChange = (e) => {
     const { id: inputName, value } = e.target;
     switch (inputName) {
       case "name":
-        setEditSelfContent({
-          ...editSelfContent,
+        setEditContent({
+          ...editContent,
           name: value,
         });
         break;
       case "avatar":
-        setEditSelfContent({
-          ...editSelfContent,
+        setEditContent({
+          ...editContent,
           avatar: value,
         });
         break;
       case "contactEmail":
-        setEditSelfContent({
-          ...editSelfContent,
+        setEditContent({
+          ...editContent,
           contactEmail: value,
         });
         break;
       default:
-        return editSelfContent;
+        return editContent;
     }
   };
   return (
@@ -77,24 +76,24 @@ function SelfPage() {
       <EditContainer>
         <SectionText>個人資訊</SectionText>
         <RowContainer>
-          <EditButton onClick={handleSelfEditClick}>
-            {isEditingSelf ? "取消編輯" : "編輯個人資訊"}
+          <EditButton onClick={handleEditClick}>
+            {isEditing ? "取消編輯" : "編輯個人資訊"}
           </EditButton>
-          {isEditingSelf && (
+          {isEditing && (
             <SubmitButton onClick={handleSelfSubmitClick}>
               編輯完成
             </SubmitButton>
           )}
         </RowContainer>
       </EditContainer>
-      <FormItemContainer show={!isEditingSelf}>
+      <FormItemContainer show={!isEditing}>
         <ItemTop>
           <ItemName>Name</ItemName>
         </ItemTop>
         {teacherInfos && (
           <ItemBottom>
-            <ItemValue show={!isEditingSelf}>{teacherInfos.name}</ItemValue>
-            {isEditingSelf && (
+            <ItemValue show={!isEditing}>{teacherInfos.name}</ItemValue>
+            {isEditing && (
               <EditInput
                 defaultValue={teacherInfos.name}
                 onChange={handleSelfInputChange}
@@ -104,14 +103,14 @@ function SelfPage() {
           </ItemBottom>
         )}
       </FormItemContainer>
-      <FormItemContainer show={!isEditingSelf}>
+      <FormItemContainer show={!isEditing}>
         <ItemTop>
           <ItemName>Avatar</ItemName>
         </ItemTop>
         {teacherInfos && (
           <ItemBottom>
-            <ItemValue show={!isEditingSelf}>{teacherInfos.avatar}</ItemValue>
-            {isEditingSelf && teacherInfos && (
+            <ItemValue show={!isEditing}>{teacherInfos.avatar}</ItemValue>
+            {isEditing && teacherInfos && (
               <EditInput
                 defaultValue={teacherInfos.avatar}
                 onChange={handleSelfInputChange}
@@ -121,16 +120,14 @@ function SelfPage() {
           </ItemBottom>
         )}
       </FormItemContainer>
-      <FormItemContainer show={!isEditingSelf}>
+      <FormItemContainer show={!isEditing}>
         <ItemTop>
           <ItemName>Contact Email</ItemName>
         </ItemTop>
         {teacherInfos && (
           <ItemBottom>
-            <ItemValue show={!isEditingSelf}>
-              {teacherInfos.contactEmail}
-            </ItemValue>
-            {isEditingSelf && teacherInfos && (
+            <ItemValue show={!isEditing}>{teacherInfos.contactEmail}</ItemValue>
+            {isEditing && teacherInfos && (
               <EditInput
                 defaultValue={teacherInfos.contactEmail}
                 onChange={handleSelfInputChange}

--- a/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
+++ b/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
@@ -2,17 +2,17 @@ import { useState } from "react";
 
 function useEdit() {
   //資訊是否為編輯狀態
-  const [isEditingSelf, setIsEditingSelf] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   //存取編輯內容
-  const [editSelfContent, setEditSelfContent] = useState(null);
+  const [editContent, setEditContent] = useState(null);
   //處理編輯按鈕被按
-  const handleSelfEditClick = () => setIsEditingSelf(!isEditingSelf);
+  const handleEditClick = () => setIsEditing(!isEditing);
   return {
-    isEditingSelf,
-    setIsEditingSelf,
-    editSelfContent,
-    setEditSelfContent,
-    handleSelfEditClick,
+    isEditing,
+    setIsEditing,
+    editContent,
+    setEditContent,
+    handleEditClick,
   };
 }
 

--- a/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
+++ b/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+function useEdit() {
+  //資訊是否為編輯狀態
+  const [isEditingSelf, setIsEditingSelf] = useState(false);
+  //存取編輯內容
+  const [editSelfContent, setEditSelfContent] = useState(null);
+  //處理編輯按鈕被按
+  const handleSelfEditClick = () => setIsEditingSelf(!isEditingSelf);
+  return {
+    isEditingSelf,
+    setIsEditingSelf,
+    editSelfContent,
+    setEditSelfContent,
+    handleSelfEditClick,
+  };
+}
+
+export default useEdit;


### PR DESCRIPTION
有鑒於老師後台的頁面有 449 行有點太可怕，所以我又將課程頁面整理了一下，變得比較簡潔。

### Context
1. 修復上次 PR 提到課程頁面編輯完後會強制跳到第一個課程頁面的問題
2. 將個人資訊與課程資訊頁面的編輯狀態整理成 useEdit hook 並引入
3. 將課程資訊頁面的 styled components 切出：CategoryDropDownMenu、PublishedRadiosContainer、PageStyle
4. Web API 加上老師後台取得資料所需的 function(還沒串只是寫上去而已)

### Notes
基本上都沒有新的功能，再請協助測試功能有無問題。