### PR TITLE
老師後台：RWD、填答驗證、新增 confirm alert、串 API

### DIFF
--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -67,7 +67,7 @@ export const register = async (
   }
 };
 
-export const getTeacherInfos = async () => {
+export const getTeacherInfos = async (setApiEror) => {
   let url = `${BASE_URL}/teacher/info`;
   const token = getAuthToken();
   try {
@@ -81,6 +81,8 @@ export const getTeacherInfos = async () => {
     if (!res.ok) throw new Error("fail to fetch data");
     return await res.json();
   } catch (error) {
+    setApiEror("發生了一點錯誤，請稍後再試");
+    console.log(error.message);
     return error.message;
   }
 };

--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -63,7 +63,7 @@ export const register = async (
     });
     return await res.json();
   } catch (error) {
-    return console.log(error.message);
+    return error.message;
   }
 };
 

--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -67,8 +67,8 @@ export const register = async (
   }
 };
 
-export const getTeacherInfos = async (teacherId) => {
-  let url = `${BASE_URL}/teacher/${teacherId}/info`;
+export const getTeacherInfos = async () => {
+  let url = `${BASE_URL}/teacher/info`;
   const token = getAuthToken();
   try {
     const res = await fetch(url, {

--- a/skilfor/src/components/AlertCard/AlertCard.js
+++ b/skilfor/src/components/AlertCard/AlertCard.js
@@ -1,0 +1,20 @@
+import {
+  AlertContainer,
+  AlertTitle,
+  AlertContent,
+  AlertButton,
+} from "../Calendar/AddTaskAlertCard";
+
+function AlertCard({ color, title, content, handleAlertOkClick }) {
+  return (
+    <AlertContainer color={color}>
+      <AlertTitle>{title}</AlertTitle>
+      <AlertContent>{content}</AlertContent>
+      <AlertButton color={color} onClick={handleAlertOkClick}>
+        OK
+      </AlertButton>
+    </AlertContainer>
+  );
+}
+
+export default AlertCard;

--- a/skilfor/src/components/AlertCard/index.js
+++ b/skilfor/src/components/AlertCard/index.js
@@ -1,0 +1,2 @@
+import AlertCard from "./AlertCard";
+export default AlertCard;

--- a/skilfor/src/pages/TeacherManagePage/Constant.js
+++ b/skilfor/src/pages/TeacherManagePage/Constant.js
@@ -15,7 +15,7 @@ export const COURSE_LIST = [
       "經過幾年的發展，Spring Boot 的功能已經非常成熟，並且在近幾年軟體業盛行微服務（microservice）的設計模式下，也帶動越來越多企業選擇使用 Spring Boot 作為主流的開發工具。Spring Boot 之所以能夠成為目前業界最流行的開發工具，原因就在於 Spring Boot 憑借著 簡化 Spring 開發 以及 快速整合主流框架 的優點，讓工程師們可以更專注的在解決問題上，進而提升了前期開發和後續部署的效率。",
     price: 1000,
     audit: "success",
-    published: true,
+    published: false,
   },
   {
     id: "course_456",

--- a/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
+++ b/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Avatar from "../../components/Avatar";
 import teacherPic from "../../img/teacher.jpeg";
@@ -7,6 +7,7 @@ import CoursePage from "./components/CoursePage";
 import SelfPage from "./components/SelfPage";
 import { MEDIA_QUERY_MD } from "../../components/constants/breakpoints";
 import useCheckToken from "./hooks/useCheckToken";
+import { getTeacherInfos } from "../../WebAPI.js";
 
 //styled component
 const TeacherManageWrapper = styled.section`
@@ -87,6 +88,19 @@ function TeacherManagePage() {
   useCheckToken();
   //個人資料或課程資料頁面
   const [page, setPage] = useState("self");
+  //老師個人資訊
+  const [teacherInfos, setTeacherInfos] = useState(null);
+  const [apiError, setApiEror] = useState(false);
+  useEffect(() => {
+    const getData = async (setApiEror) => {
+      let json = await getTeacherInfos(setApiEror);
+      if (json.errMessage) {
+        setApiEror("請先登入才能使用後台功能");
+      }
+      setTeacherInfos(json.data);
+    };
+    getData(setApiEror);
+  }, []);
   //當個人資訊與課程資訊按鈕被按時
   const handlePageBtnClick = (e) => {
     const { id: currentPage } = e.target;
@@ -97,7 +111,9 @@ function TeacherManagePage() {
       <PageTitle>後台管理</PageTitle>
       <TeacherManageContainer>
         <UserInfoContainer>
-          <Avatar imgSrc={teacherPic} name="Kelly" />
+          {teacherInfos && (
+            <Avatar imgSrc={teacherPic} name={teacherInfos.username} />
+          )}
           <PageBtnsContainer>
             <PageBtn
               id="self"
@@ -116,7 +132,14 @@ function TeacherManagePage() {
           </PageBtnsContainer>
         </UserInfoContainer>
         <FormContainer>
-          {page === "self" && <SelfPage />}
+          {page === "self" && (
+            <SelfPage
+              teacherInfos={teacherInfos}
+              setTeacherInfos={setTeacherInfos}
+              apiError={apiError}
+              setApiEror={setApiEror}
+            />
+          )}
           {page === "course" && <CoursePage />}
         </FormContainer>
       </TeacherManageContainer>

--- a/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
+++ b/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
@@ -5,35 +5,40 @@ import teacherPic from "../../img/teacher.jpeg";
 import PageTitle from "../../components/PageTitle";
 import CoursePage from "./components/CoursePage";
 import SelfPage from "./components/SelfPage";
+import { MEDIA_QUERY_MD } from "../../components/constants/breakpoints";
 
 //styled component
 const TeacherManageWrapper = styled.section`
-  padding: 186px 100px 232px 100px;
+  padding: 156px 80px 232px 80px;
+  ${MEDIA_QUERY_MD} {
+    padding: 156px 30px 182px 30px;
+  }
 `;
-
 export const RowContainer = styled.div`
   display: flex;
 `;
-
 const ColumnContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
-
 const TeacherManageContainer = styled(RowContainer)`
   margin-bottom: 30px;
+  ${MEDIA_QUERY_MD} {
+    flex-direction: column;
+  }
 `;
-
 const UserInfoContainer = styled(ColumnContainer)`
   background: ${(props) => props.theme.colors.grey_bg};
   min-width: 200px;
   margin-right: 50px;
+  ${MEDIA_QUERY_MD} {
+    margin-right: 0px;
+    margin-bottom: 40px;
+  }
 `;
-
 const PageBtnsContainer = styled(ColumnContainer)`
   padding: 20px 25px;
 `;
-
 const PageBtn = styled.button`
   color: ${(props) => (props.isClick ? "white" : props.theme.colors.grey_dark)};
   background: ${(props) => props.isClick && props.theme.colors.orange};
@@ -44,7 +49,6 @@ const PageBtn = styled.button`
   border-radius: 10px;
   cursor: pointer;
 `;
-
 const FormContainer = styled(ColumnContainer)`
   width: 100%;
   min-height: 500px;
@@ -52,19 +56,16 @@ const FormContainer = styled(ColumnContainer)`
   border-radius: 10px;
   padding: 20px;
 `;
-
 export const SectionText = styled.h3`
   font-size: 1.3rem;
   color: ${(props) => props.theme.colors.green_dark};
   margin: 10px 0 20px 0;
 `;
-
 export const EditContainer = styled(RowContainer)`
   justify-content: space-between;
   align-items: baseline;
   margin-top: 10px;
 `;
-
 export const EditButton = styled.button`
   background: ${(props) => props.theme.colors.green_dark};
   border: none;
@@ -77,7 +78,6 @@ export const EditButton = styled.button`
     opacity: 0.8;
   }
 `;
-
 export const SubmitButton = styled(EditButton)`
   margin-left: 15px;
 `;

--- a/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
+++ b/skilfor/src/pages/TeacherManagePage/TeacherManagePage.js
@@ -6,6 +6,7 @@ import PageTitle from "../../components/PageTitle";
 import CoursePage from "./components/CoursePage";
 import SelfPage from "./components/SelfPage";
 import { MEDIA_QUERY_MD } from "../../components/constants/breakpoints";
+import useCheckToken from "./hooks/useCheckToken";
 
 //styled component
 const TeacherManageWrapper = styled.section`
@@ -83,6 +84,7 @@ export const SubmitButton = styled(EditButton)`
 `;
 
 function TeacherManagePage() {
+  useCheckToken();
   //個人資料或課程資料頁面
   const [page, setPage] = useState("self");
   //當個人資訊與課程資訊按鈕被按時

--- a/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
@@ -6,7 +6,9 @@ import { sleep } from "../../../utils";
 const RowContainer = styled.div`
   display: flex;
 `;
-const SelectContainer = styled(RowContainer)``;
+const SelectContainer = styled(RowContainer)`
+  margin-bottom: 20px;
+`;
 const SelectBar = styled.select`
   padding: 5px;
   font-size: 1rem;

--- a/skilfor/src/pages/TeacherManagePage/components/CourseInfosForm.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CourseInfosForm.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { MEDIA_QUERY_SM } from "../../../components/constants/breakpoints";
 
 const RowContainer = styled.div`
   display: flex;
@@ -31,14 +32,19 @@ export const EditInput = styled.input`
   padding: 5px;
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
+  border: 1px solid ${(props) => props.theme.colors.grey_dark};
   ${(props) => props.error && `border: 2px solid ${props.theme.colors.error}`}
 `;
 const EditTextArea = styled.textarea`
-  height: 100px;
+  height: 150px;
   padding: 5px;
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
+  border: 1px solid ${(props) => props.theme.colors.grey_dark};
   ${(props) => props.error && `border: 2px solid ${props.theme.colors.error}`}
+  ${MEDIA_QUERY_SM} {
+    height: 200px;
+  }
 `;
 function CourseInfosForm({
   isEditing,

--- a/skilfor/src/pages/TeacherManagePage/components/CourseInfosForm.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CourseInfosForm.js
@@ -3,75 +3,73 @@ import styled from "styled-components";
 const RowContainer = styled.div`
   display: flex;
 `;
-
 const ColumnContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
-
 export const FormItemContainer = styled(ColumnContainer)`
   border-bottom: 1px solid
     ${(props) => (props.show ? props.theme.colors.grey_light : "transparent")};
   margin-bottom: 20px;
 `;
-
 export const ItemTop = styled(RowContainer)``;
-
 export const ItemBottom = styled(ColumnContainer)`
   padding: 0 15px;
   margin-bottom: 10px;
 `;
-
 export const ItemName = styled.p`
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
   margin-bottom: 10px;
 `;
-
 export const ItemValue = styled(ItemName)`
   margin-bottom: 0px;
   display: ${(props) => (props.show ? "block" : "none")};
 `;
-
 export const EditInput = styled.input`
   height: 30px;
   padding: 5px;
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
+  ${(props) => props.error && `border: 2px solid ${props.theme.colors.error}`}
 `;
-
 const EditTextArea = styled.textarea`
   height: 100px;
   padding: 5px;
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
+  ${(props) => props.error && `border: 2px solid ${props.theme.colors.error}`}
 `;
-
 function CourseInfosForm({
   isEditing,
   courseInfos,
-  editCourseContent,
-  setEditCourseContent,
+  editContent,
+  setEditContent,
+  error,
+  setError,
 }) {
   const handleInputChange = (e) => {
     const { id: inputName, value } = e.target;
     if (inputName === "courseName") {
-      setEditCourseContent({
-        ...editCourseContent,
+      setEditContent({
+        ...editContent,
         courseName: value,
       });
+      setError(error.filter((errorItem) => errorItem !== inputName));
     }
     if (inputName === "courseIntro") {
-      setEditCourseContent({
-        ...editCourseContent,
+      setEditContent({
+        ...editContent,
         courseIntro: value,
       });
+      setError(error.filter((errorItem) => errorItem !== inputName));
     }
     if (inputName === "price") {
-      setEditCourseContent({
-        ...editCourseContent,
+      setEditContent({
+        ...editContent,
         price: value,
       });
+      setError(error.filter((errorItem) => errorItem !== inputName));
     }
   };
   return (
@@ -92,6 +90,7 @@ function CourseInfosForm({
           <ItemValue show={!isEditing}>{courseInfos.courseName}</ItemValue>
           {isEditing && courseInfos && (
             <EditInput
+              error={error.includes("courseName")}
               defaultValue={courseInfos.courseName}
               onChange={handleInputChange}
               id="courseName"
@@ -107,6 +106,7 @@ function CourseInfosForm({
           <ItemValue show={!isEditing}>{courseInfos.courseIntro}</ItemValue>
           {isEditing && courseInfos && (
             <EditTextArea
+              error={error.includes("courseIntro")}
               defaultValue={courseInfos.courseIntro}
               onChange={handleInputChange}
               id="courseIntro"
@@ -122,9 +122,11 @@ function CourseInfosForm({
           <ItemValue show={!isEditing}>{courseInfos.price}</ItemValue>
           {isEditing && courseInfos && (
             <EditInput
+              error={error.includes("price")}
               defaultValue={courseInfos.price}
               onChange={handleInputChange}
               id="price"
+              type="number"
             />
           )}
         </ItemBottom>

--- a/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
@@ -174,8 +174,24 @@ function CoursePage() {
     console.log("PUT", updatedCourseInfos);
   };
   //當是否發布到前台被按時
-  const handleRadioClick = (e) => {
-    const { id: publishedValue } = e.target;
+  const handleRadioChange = (e) => {
+    const { value: publishedValue } = e.target;
+    if (selectedCourseInfos.published === (publishedValue === "true")) return;
+    let confirmAlert;
+    if (publishedValue === "true") {
+      confirmAlert = window.confirm(
+        "確定要將課程資訊上架到前台嗎？(上架到前台後，任何人都可以瀏覽你的課程頁面，並可預約你的課程)"
+      );
+    } else {
+      confirmAlert = window.confirm(
+        "確定要將課程資訊暫時隱藏嗎？(從前台隱藏後，其他人將無法瀏覽你的課程頁面，也無法預約你的課程)"
+      );
+    }
+    if (!confirmAlert) return;
+    setSelectedCourseInfos({
+      ...selectedCourseInfos,
+      published: publishedValue === "true",
+    });
     setCourseInfos(
       courseInfos.map((course) => {
         if (course.id !== selectedCourseInfos.id) {
@@ -310,7 +326,7 @@ function CoursePage() {
             <>
               <SectionText>是否發布課程頁面</SectionText>
               <PublishedRadiosContainer
-                handleRadioClick={handleRadioClick}
+                handleRadioChange={handleRadioChange}
                 published={selectedCourseInfos.published}
               />
             </>

--- a/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
@@ -52,8 +52,9 @@ const DeleteButton = styled(EditButton)`
   margin-right: 15px;
 `;
 const CourseBtnsContainer = styled(RowContainer)`
-  margin-bottom: 25px;
+  margin-bottom: 10px;
   align-items: center;
+  flex-wrap: wrap;
 `;
 const CourseButton = styled.button`
   padding: 6px 15px;
@@ -63,6 +64,7 @@ const CourseButton = styled.button`
   border: 2px solid ${(props) => props.theme.colors.grey_dark};
   background: white;
   cursor: pointer;
+  margin-bottom: 15px;
   :not(:last-child) {
     margin-right: 20px;
   }
@@ -216,9 +218,7 @@ function CoursePage() {
         setSelectedCourseInfos={setSelectedCourseInfos}
         setEditContent={setEditContent}
       />
-      <EditContainer>
-        <SectionText>目前擁有的課程</SectionText>
-      </EditContainer>
+      <SectionText>目前擁有的課程</SectionText>
       {courseInfos && courseInfos.length !== 0 && selectedCourseInfos && (
         <CourseBtnsContainer>
           {courseInfos.map((course) => (

--- a/skilfor/src/pages/TeacherManagePage/components/PageStyle.js
+++ b/skilfor/src/pages/TeacherManagePage/components/PageStyle.js
@@ -1,21 +1,23 @@
 import styled from "styled-components";
+import { MEDIA_QUERY_SM } from "../../../components/constants/breakpoints";
 
 export const RowContainer = styled.div`
   display: flex;
 `;
-
 export const SectionText = styled.h3`
   font-size: 1.3rem;
   color: ${(props) => props.theme.colors.green_dark};
-  margin: 10px 0 20px 0;
+  margin: 10px 10px 20px 0;
 `;
-
 export const EditContainer = styled(RowContainer)`
   justify-content: space-between;
   align-items: baseline;
   margin-top: 10px;
+  ${MEDIA_QUERY_SM} {
+    flex-direction: column;
+    margin-bottom: 30px;
+  }
 `;
-
 export const EditButton = styled.button`
   background: ${(props) => props.theme.colors.green_dark};
   border: none;
@@ -28,7 +30,6 @@ export const EditButton = styled.button`
     opacity: 0.8;
   }
 `;
-
 export const SubmitButton = styled(EditButton)`
   margin-left: 15px;
 `;

--- a/skilfor/src/pages/TeacherManagePage/components/PublishedRadiosContainer.js
+++ b/skilfor/src/pages/TeacherManagePage/components/PublishedRadiosContainer.js
@@ -21,26 +21,28 @@ const RadioLabel = styled.label`
   margin-left: 5px;
 `;
 
-const PublishedRadiosContainer = ({ handleRadioClick, published }) => {
+const PublishedRadiosContainer = ({ handleRadioChange, published }) => {
   return (
     <RadiosContainer>
       <RadioContainer>
         <RadioInput
-          onClick={handleRadioClick}
+          onChange={handleRadioChange}
           name="published"
           type="radio"
           id="true"
-          defaultChecked={published}
+          checked={published}
+          value={true}
         />
         <RadioLabel htmlFor="true">一切都 OK！發布至前台</RadioLabel>
       </RadioContainer>
       <RadioContainer>
         <RadioInput
-          defaultChecked={!published}
-          onClick={handleRadioClick}
+          onChange={handleRadioChange}
           name="published"
           type="radio"
           id="false"
+          checked={!published}
+          value={false}
         />
         <RadioLabel htmlFor="false">還有資訊需要編輯，暫時不發布</RadioLabel>
       </RadioContainer>

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -18,15 +18,30 @@ import {
 } from "./CourseInfosForm";
 import useEdit from "../hooks/useEdit";
 
+const formDataVerify = (formData) => {
+  let errorArr = [];
+  for (let question in formData) {
+    if (
+      (question === "name" ||
+        question === "avatar" ||
+        question === "contactEmail") &&
+      formData[question] === ""
+    ) {
+      errorArr.push(question);
+    }
+  }
+  return errorArr;
+};
 function SelfPage() {
   const [teacherInfos, setTeacherInfos] = useState(null);
+  const [error, setError] = useState([]);
   const {
     isEditing,
     setIsEditing,
     editContent,
     setEditContent,
     handleEditClick,
-  } = useEdit();
+  } = useEdit(setError, teacherInfos);
   //拿取 teacher infos
   useEffect(() => {
     async function fetchData() {
@@ -41,8 +56,13 @@ function SelfPage() {
   }, [teacherInfos, setEditContent]);
   //完成編輯個人資訊按鈕被按時
   const handleSelfSubmitClick = () => {
-    setIsEditing(false);
+    let errorArr = formDataVerify(editContent);
+    if (errorArr.length > 0) {
+      setError(errorArr);
+      return alert("尚有欄位未填答，請填寫完後再送出資料");
+    }
     setTeacherInfos(editContent);
+    setIsEditing(false);
     //將更改後的課程資訊 post 給後端
     console.log("PUT", editContent);
   };
@@ -95,6 +115,7 @@ function SelfPage() {
             <ItemValue show={!isEditing}>{teacherInfos.name}</ItemValue>
             {isEditing && (
               <EditInput
+                error={error.includes("name")}
                 defaultValue={teacherInfos.name}
                 onChange={handleSelfInputChange}
                 id="name"
@@ -112,6 +133,7 @@ function SelfPage() {
             <ItemValue show={!isEditing}>{teacherInfos.avatar}</ItemValue>
             {isEditing && teacherInfos && (
               <EditInput
+                error={error.includes("avatar")}
                 defaultValue={teacherInfos.avatar}
                 onChange={handleSelfInputChange}
                 id="avatar"
@@ -129,6 +151,7 @@ function SelfPage() {
             <ItemValue show={!isEditing}>{teacherInfos.contactEmail}</ItemValue>
             {isEditing && teacherInfos && (
               <EditInput
+                error={error.includes("contactEmail")}
                 defaultValue={teacherInfos.contactEmail}
                 onChange={handleSelfInputChange}
                 id="contactEmail"

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { TEACHER_INFOS } from "../Constant";
-import { sleep } from "../../../utils";
 import {
   EditContainer,
   SectionText,
@@ -17,6 +15,7 @@ import {
   EditInput,
 } from "./CourseInfosForm";
 import useEdit from "../hooks/useEdit";
+import { getTeacherInfos } from "../../../WebAPI.js";
 
 const formDataVerify = (formData) => {
   let errorArr = [];
@@ -35,6 +34,7 @@ const formDataVerify = (formData) => {
 function SelfPage() {
   const [teacherInfos, setTeacherInfos] = useState(null);
   const [error, setError] = useState([]);
+  const [apiError, setApiEror] = useState(false);
   const {
     isEditing,
     setIsEditing,
@@ -44,11 +44,11 @@ function SelfPage() {
   } = useEdit(setError, teacherInfos);
   //拿取 teacher infos
   useEffect(() => {
-    async function fetchData() {
-      await sleep(500);
-      setTeacherInfos(TEACHER_INFOS);
-    }
-    fetchData();
+    const getData = async () => {
+      let json = await getTeacherInfos();
+      setTeacherInfos(json.data);
+    };
+    getData();
   }, []);
   //設定預設課程個人編輯 value
   useEffect(() => {
@@ -112,11 +112,11 @@ function SelfPage() {
         </ItemTop>
         {teacherInfos && (
           <ItemBottom>
-            <ItemValue show={!isEditing}>{teacherInfos.name}</ItemValue>
+            <ItemValue show={!isEditing}>{teacherInfos.username}</ItemValue>
             {isEditing && (
               <EditInput
                 error={error.includes("name")}
-                defaultValue={teacherInfos.name}
+                defaultValue={teacherInfos.username}
                 onChange={handleSelfInputChange}
                 id="name"
               />

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -16,7 +16,6 @@ import {
   EditInput,
 } from "./CourseInfosForm";
 import useEdit from "../hooks/useEdit";
-import { getTeacherInfos } from "../../../WebAPI.js";
 import AlertCard from "../../../components/AlertCard/AlertCard";
 
 const formDataVerify = (formData) => {
@@ -33,11 +32,9 @@ const formDataVerify = (formData) => {
   }
   return errorArr;
 };
-function SelfPage() {
+function SelfPage({ teacherInfos, setTeacherInfos, apiError, setApiEror }) {
   const navigate = useNavigate();
-  const [teacherInfos, setTeacherInfos] = useState(null);
   const [error, setError] = useState([]);
-  const [apiError, setApiEror] = useState(false);
   const {
     isEditing,
     setIsEditing,
@@ -45,17 +42,6 @@ function SelfPage() {
     setEditContent,
     handleEditClick,
   } = useEdit(setError, teacherInfos);
-  //拿取 teacher infos
-  useEffect(() => {
-    const getData = async (setApiEror) => {
-      let json = await getTeacherInfos(setApiEror);
-      if (json.errMessage) {
-        setApiEror("請先登入才能使用後台功能");
-      }
-      setTeacherInfos(json.data);
-    };
-    getData(setApiEror);
-  }, []);
   //設定預設課程個人編輯 value
   useEffect(() => {
     setEditContent(teacherInfos);
@@ -99,7 +85,11 @@ function SelfPage() {
   };
   const handleAlertOkClick = () => {
     setApiEror(false);
-    if (apiError === "請先登入才能使用後台功能") navigate("/login");
+    if (apiError === "請先登入才能使用後台功能") {
+      navigate("/login");
+    } else {
+      navigate("/");
+    }
     return;
   };
   return (

--- a/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/SelfPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router";
 import {
   EditContainer,
   SectionText,
@@ -16,6 +17,7 @@ import {
 } from "./CourseInfosForm";
 import useEdit from "../hooks/useEdit";
 import { getTeacherInfos } from "../../../WebAPI.js";
+import AlertCard from "../../../components/AlertCard/AlertCard";
 
 const formDataVerify = (formData) => {
   let errorArr = [];
@@ -32,6 +34,7 @@ const formDataVerify = (formData) => {
   return errorArr;
 };
 function SelfPage() {
+  const navigate = useNavigate();
   const [teacherInfos, setTeacherInfos] = useState(null);
   const [error, setError] = useState([]);
   const [apiError, setApiEror] = useState(false);
@@ -44,11 +47,14 @@ function SelfPage() {
   } = useEdit(setError, teacherInfos);
   //拿取 teacher infos
   useEffect(() => {
-    const getData = async () => {
-      let json = await getTeacherInfos();
+    const getData = async (setApiEror) => {
+      let json = await getTeacherInfos(setApiEror);
+      if (json.errMessage) {
+        setApiEror("請先登入才能使用後台功能");
+      }
       setTeacherInfos(json.data);
     };
-    getData();
+    getData(setApiEror);
   }, []);
   //設定預設課程個人編輯 value
   useEffect(() => {
@@ -91,8 +97,21 @@ function SelfPage() {
         return editContent;
     }
   };
+  const handleAlertOkClick = () => {
+    setApiEror(false);
+    if (apiError === "請先登入才能使用後台功能") navigate("/login");
+    return;
+  };
   return (
     <>
+      {apiError && (
+        <AlertCard
+          color="#A45D5D"
+          title="錯誤"
+          content={apiError}
+          handleAlertOkClick={handleAlertOkClick}
+        />
+      )}
       <EditContainer>
         <SectionText>個人資訊</SectionText>
         <RowContainer>

--- a/skilfor/src/pages/TeacherManagePage/hooks/useCheckToken.js
+++ b/skilfor/src/pages/TeacherManagePage/hooks/useCheckToken.js
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+import { getAuthToken } from "../../../utils";
+import { useNavigate } from "react-router-dom";
+
+function useCheckToken() {
+  const authToken = useRef();
+  const navigate = useNavigate();
+  useEffect(() => {
+    authToken.current = getAuthToken();
+    if (!authToken.current) navigate("/");
+  }, [navigate]);
+  return;
+}
+
+export default useCheckToken;

--- a/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
+++ b/skilfor/src/pages/TeacherManagePage/hooks/useEdit.js
@@ -1,12 +1,18 @@
 import { useState } from "react";
 
-function useEdit() {
+function useEdit(setError, displayData) {
   //資訊是否為編輯狀態
   const [isEditing, setIsEditing] = useState(false);
   //存取編輯內容
   const [editContent, setEditContent] = useState(null);
   //處理編輯按鈕被按
-  const handleEditClick = () => setIsEditing(!isEditing);
+  const handleEditClick = () => {
+    if (isEditing) {
+      setError([]);
+      setEditContent(displayData);
+    }
+    setIsEditing(!isEditing);
+  };
   return {
     isEditing,
     setIsEditing,

--- a/skilfor/src/utils.js
+++ b/skilfor/src/utils.js
@@ -9,5 +9,5 @@ export const setAuthToken = (token) => {
 };
 
 export const getAuthToken = () => {
-  localStorage.getItem(TOKEN_NAME);
+  return localStorage.getItem(TOKEN_NAME);
 };


### PR DESCRIPTION
### Context
1. 老師後台個人資訊與課程資訊頁面：RWD、填答驗證(若沒填按送出會跳 alert & 框框會成警示色)
2. 老師後台主頁：串好 teacher infos API
3. 老師後台課程頁面：使用者切換是否發布前台前，跳一個 confirm alert
4. 新增 useCheckToken hook 來做後台的登入驗證，若沒能拿到 token 就會強制導到登入頁
5. 新增 apiError state & AlertCard 用於發生 API 錯誤時將錯誤訊息顯示於前台

### Note
1. 填答驗證：
![image](https://user-images.githubusercontent.com/72880137/144438486-bff860a7-c382-4248-ad1e-1ccadbaf50a8.png)
2. AlertCard(此 component 可以用於任何的錯誤訊息顯示，已放在 components 資料夾中，歡迎取用！)：
![image](https://user-images.githubusercontent.com/72880137/144438980-8d7087c2-d2a8-40fd-b3f9-6450274b3280.png)
3. 之所以不用 useLogin 而用 useCheckToken hook 來確認登入的原因是，後台頁面不會用到 user 的資料，而且用 useContext 抓 user 一開始會是 null，所以拿它來判斷一開始就會出錯 qq 若有什麼解方歡迎告訴我～(話說用 token 來判斷登入應該也是可以？因為有登入才會有 token）

## Todos
1. 繼續串後台頁面 API
2. 若 1. 完成會來加強行事曆
