### PR TITLE
新增 Filterpage API

### DIFF
--- a/skilfor/src/WebAPI.js
+++ b/skilfor/src/WebAPI.js
@@ -27,6 +27,7 @@ export const getMyUserData = async () => {
   try {
     const token = getAuthToken();
     const res = await fetch(`${BASE_URL}/members/me`, {
+      method: "GET",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
@@ -195,6 +196,40 @@ export const deleteCourse = async (setApiError, courseId) => {
       body: JSON.stringify({
         id: courseId,
       }),
+    });
+    if (!res.ok) throw new Error("fail to fetch data");
+    return await res.json();
+  } catch (error) {
+    setApiError("發生了一點錯誤，請稍後再試");
+    return error.message;
+  }
+};
+
+export const getSpecificCourse = async (categoryName, setApiError) => {
+  let url = `${BASE_URL}/filter/course/${categoryName}`;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (!res.ok) throw new Error("fail to fetch data");
+    return await res.json();
+  } catch (error) {
+    setApiError("發生了一點錯誤，請稍後再試");
+    return error.message;
+  }
+};
+
+export const getAllCourses = async (setApiError) => {
+  let url = `${BASE_URL}/filter/course`;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
     });
     if (!res.ok) throw new Error("fail to fetch data");
     return await res.json();

--- a/skilfor/src/pages/FilterPage/FilterPage.js
+++ b/skilfor/src/pages/FilterPage/FilterPage.js
@@ -73,10 +73,6 @@ const DropdownBtn = styled.button`
   }
 `;
 
-const DropdownInput = styled.input`
-  display: none;
-`;
-
 const DropdownMenu = styled.ul`
   position: absolute;
   top: 100%;
@@ -89,7 +85,8 @@ const DropdownMenu = styled.ul`
   list-style-type: none;
   width: 100%;
   z-index: 2;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
   height: 180px;
   ${MEDIA_QUERY_SM} {
     height: 220px;
@@ -183,7 +180,6 @@ function FilterPage() {
       if (json.data.indexOf("目前尚未有課程") === 0) {
         return setCourseError("目前尚未有課程");
       }
-      // if (currentCategoryName === "") return;
       console.log(json.data);
       setCourseResults(json.data);
     };
@@ -236,13 +232,12 @@ function FilterPage() {
         <DropdownBtn onClick={handleDropdownMenuToggle}>
           {currentCategoryDisplayName}
         </DropdownBtn>
-        <DropdownInput type="checkbox" id="select" />
         {dropdownMenu && (
           <DropdownMenu>
             {dropdownContent.map((categories) => (
               <DropdownContent
                 onClick={handleCategoryClick}
-                key={categories.teacherId}
+                key={categories.id}
                 id={categories.name}
               >
                 {categories.displayName}
@@ -253,7 +248,10 @@ function FilterPage() {
       </DropdownLabel>
       <ResultList>
         {courseResults.map((courseResult) => (
-          <TeacherFilterResult key={courseResult.id} result={courseResult} />
+          <TeacherFilterResult
+            key={courseResult.courseId}
+            result={courseResult}
+          />
         ))}
       </ResultList>
     </Container>

--- a/skilfor/src/pages/FilterPage/TeacherFilterResult.js
+++ b/skilfor/src/pages/FilterPage/TeacherFilterResult.js
@@ -80,6 +80,10 @@ const BtnDiv = styled.div`
   justify-content: space-between;
   align-items: flex-end;
   padding: 2px 8px 2px 0px;
+  height: 100px;
+  ${MEDIA_QUERY_SM} {
+    height: 65px;
+  }
 `;
 
 const CoursePrice = styled.p`

--- a/skilfor/src/pages/FilterPage/TeacherFilterResult.js
+++ b/skilfor/src/pages/FilterPage/TeacherFilterResult.js
@@ -128,7 +128,7 @@ function TeacherFilterResult({ result }) {
           <CourseName>{result.courseName}</CourseName>
           <CourseIntro>{result.courseDescription}</CourseIntro>
           <BtnDiv>
-            <CoursePrice>{result.price}</CoursePrice>
+            <CoursePrice>NT${result.price}</CoursePrice>
             <Btn to={`/teacher/profile/${result.teacherId}`}>更多資訊</Btn>
           </BtnDiv>
         </CourseBlock>


### PR DESCRIPTION
**主要**
1. 串好 Filter Page 的三支 API
- **getAllCourses**：剛進入 FilterPage 會 render 所有目前資料庫有的課程資料，目前後端設定共有三堂課程(生活品味1堂&音樂2堂)
- **getAllCategories**：點選下拉選單會抓所有 category 的資料
- **getSpecificCourse**：點選下拉選單中的領域會抓出某領域中的課程資料，目前後端設定有資料的是"生活品味"與"音樂"這兩個 category
2. 打 API 後的錯誤處理，有加上 Hazel 之前寫好的 AlertCard 來顯示錯誤。

**問題**
1. 目前 AlertCard 位置的擺放有點問題，如果是放在Container底下，那畫面的Y軸比較長的時候，會需要滾動滑鼠到下方去關掉alert。如果是像目前放在DropdownLabel底下，alert視窗的位置又會太高，這部分如果有好的建議歡迎提供。

**其他**
1. 之前說打算 Filter Page 的下拉選單 style 要改成 select 跟 option 的搭配，但嘗試了之後發現 UI 有點不好看，因為 select 選單有固定格式，如果整個格式清除，只能靠 option 來產生 style ，但 option 本身可以加的樣式不多，所以我打算還是留著目前的樣子。
2. 然後本來要改select&option也是為了要解決 auto close 的問題，現在覺得加上跟 Burger Menu 差不多的功能應該就能解決了。