### PR TITLE
老師後台行事曆與前台課程頁面 RWD 、 新增課程前台行事曆 component

### DIFF
--- a/skilfor/src/components/App/App.js
+++ b/skilfor/src/components/App/App.js
@@ -68,7 +68,7 @@ function App() {
                 element={<TeacherManagePage />}
               />
               <Route
-                path="/teacher/profile/:teacherId"
+                path="/course/:courseId"
                 element={<TeacherProfilePage />}
               />
               <Route

--- a/skilfor/src/components/App/App.js
+++ b/skilfor/src/components/App/App.js
@@ -7,7 +7,7 @@ import { AuthContext, AuthLoadingContext } from "../../contexts";
 import { getMyUserData } from "../../WebAPI";
 import { getAuthToken } from "../../utils";
 import TeacherManagePage from "../../pages/TeacherManagePage";
-import TeacherProfilePage from "../../pages/TeacherProfilePage";
+import FrontCoursePage from "../../pages/FrontCoursePage";
 import HomePage from "../../pages/HomePage";
 import LoginPage from "../../pages/LoginPage";
 import RegisterPage from "../../pages/RegisterPage";
@@ -67,10 +67,7 @@ function App() {
                 path="/teacher/manage/:teacherId"
                 element={<TeacherManagePage />}
               />
-              <Route
-                path="/course/:courseId"
-                element={<TeacherProfilePage />}
-              />
+              <Route path="/course/:courseId" element={<FrontCoursePage />} />
               <Route
                 path="/teacher/calendar/:teacherId"
                 element={<TeacherCalendarPage />}

--- a/skilfor/src/components/Avatar/Avatar.js
+++ b/skilfor/src/components/Avatar/Avatar.js
@@ -24,7 +24,7 @@ export const AvatarContainer = styled.div`
   background-repeat: no-repeat;
 `;
 
-const AvatarName = styled.p`
+export const AvatarName = styled.p`
   color: white;
   font-size: 1.2rem;
   margin-top: 12px;

--- a/skilfor/src/components/Calendar/AddTaskAlertCard.js
+++ b/skilfor/src/components/Calendar/AddTaskAlertCard.js
@@ -22,7 +22,7 @@ export const ColumnContainer = styled(RowContainer)`
   align-items: center;
 `;
 export const AlertContainer = styled.div`
-  width: 350px;
+  max-width: 350px;
   position: absolute;
   left: 50%;
   top: 50%;

--- a/skilfor/src/components/Calendar/ReadTaskAlertCard.js
+++ b/skilfor/src/components/Calendar/ReadTaskAlertCard.js
@@ -13,6 +13,10 @@ const ContentContainer = styled.div``;
 const WrapContent = styled(AlertContent)`
   overflow-wrap: break-word;
 `;
+const getDisplayDate = (dateObj) => {
+  let dateStr = dateObj.toLocaleString();
+  return dateStr.slice(0, dateStr.length - 3);
+};
 
 function ReadTaskAlertCard({
   allEvents,
@@ -34,10 +38,7 @@ function ReadTaskAlertCard({
       <CloseButton src={close} onClick={handleCloseClick} />
       <AlertTitle>
         {selectedEvent.title} <br />
-        {`${
-          selectedEvent.start.getMonth() + 1
-        }/${selectedEvent.start.getDate()}`}
-        {` ${selectedEvent.resource.timePeriod}`}
+        {getDisplayDate(selectedEvent.start)}
       </AlertTitle>
       <ContentContainer>
         {selectedEvent.resource.reserved ? (

--- a/skilfor/src/components/Calendar/TeacherManageCalendar.js
+++ b/skilfor/src/components/Calendar/TeacherManageCalendar.js
@@ -57,12 +57,14 @@ function TeacherManageCalendar({ teacherId }) {
         border: `2px solid ${eventColor}`,
         backgroundColor: "white",
         color: "black",
+        fontSize: "14px",
       };
     } else {
       style = {
         border: `2px solid ${eventColor}`,
         backgroundColor: eventColor,
         color: "white",
+        fontSize: "14px",
       };
     }
     return {
@@ -92,7 +94,7 @@ function TeacherManageCalendar({ teacherId }) {
         localizer={localizer}
         startAccessor="start"
         endAccessor="end"
-        style={{ height: 500 }}
+        style={{ height: "100vh" }}
         events={allEvents}
         // onView={handleViewChange}
         // onRangeChange={handleRangeChange}

--- a/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
+++ b/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
@@ -1,16 +1,15 @@
+import { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router";
 import { AvatarContainer } from "../../components/Avatar/Avatar";
 import FrontCourseCalendar from "./components/FrontCourseCalendar";
-import teacher from "../../img/teacher.jpeg";
-import student1 from "../../img/student1.png";
-import student2 from "../../img/student2.jpeg";
-import student3 from "../../img/student3.jpeg";
 import CommentCard from "./components/CommentCard";
 import {
   MEDIA_QUERY_MD,
   MEDIA_QUERY_SM,
 } from "../../components/constants/breakpoints";
+import { TEACHER_INFOS, COURSE_INFOS, COMMENTS } from "./constants";
+import { sleep } from "../../utils";
 
 const TeacherProfileWrapper = styled.section`
   padding: 180px 200px 232px 200px;
@@ -81,59 +80,74 @@ const SectionIntro = styled(ItemContent)`
   font-size: 1.1rem;
 `;
 const CommentsContainer = styled(ColumnContainer)``;
+const NoStatusText = styled.p`
+  color: ${(props) => props.theme.colors.grey_dark};
+  font-size: 1.2rem;
+`;
 
 function FrontCoursePage() {
+  window.scroll(0, 0);
   const { courseId } = useParams();
+  const [teacherInfos, setTeacherInfos] = useState(null);
+  const [courseInfos, setCourseInfos] = useState(null);
+  const [comments, setComments] = useState(null);
+
+  const FetchData = useCallback(async () => {
+    await sleep(500);
+    setTeacherInfos(TEACHER_INFOS);
+    setCourseInfos(COURSE_INFOS);
+    setComments(COMMENTS);
+  }, []);
+  useEffect(() => {
+    FetchData();
+  });
+
   return (
     <TeacherProfileWrapper>
       <TeacherInfosContainer>
         <TeacherAvatarContainer>
-          <TeacherAvatar imgSrc={teacher} name="Kelly" />
-          <AvatarName>Kelly</AvatarName>
+          {teacherInfos && (
+            <>
+              <TeacherAvatar imgSrc={teacherInfos.avatar} />
+              <AvatarName>{teacherInfos.username}</AvatarName>
+            </>
+          )}
         </TeacherAvatarContainer>
+
         <CourseInfosContainer>
           <ItemContainer>
             <ItemTitle>領域</ItemTitle>
-            <ItemContent>程式</ItemContent>
+            {courseInfos && <ItemContent>{courseInfos.category}</ItemContent>}
           </ItemContainer>
           <ItemContainer>
             <ItemTitle>課程名稱</ItemTitle>
-            <ItemContent>一起來學習超潮的 Ruby 吧！</ItemContent>
+            {courseInfos && <ItemContent>{courseInfos.courseName}</ItemContent>}
           </ItemContainer>
           <ItemContainer>
             <ItemTitle>單堂價格</ItemTitle>
-            <ItemContent>1000</ItemContent>
+            {courseInfos && <ItemContent>{courseInfos.price}</ItemContent>}
           </ItemContainer>
         </CourseInfosContainer>
       </TeacherInfosContainer>
       <SectionTitle>課程時間</SectionTitle>
       <FrontCourseCalendar courseId={courseId} />
       <SectionTitle>課程介紹</SectionTitle>
-      <SectionIntro>
-        經過幾年的發展，Spring Boot
-        的功能已經非常成熟，並且在近幾年軟體業盛行微服務（microservice）的設計模式下，也帶動越來越多企業選擇使用
-        Spring Boot 作為主流的開發工具。Spring Boot
-        之所以能夠成為目前業界最流行的開發工具，原因就在於 Spring Boot 憑借著
-        簡化 Spring 開發 以及 快速整合主流框架
-        的優點，讓工程師們可以更專注的在解決問題上，進而提升了前期開發和後續部署的效率。
-      </SectionIntro>
+      {courseInfos && (
+        <SectionIntro>{courseInfos.courseDescription}</SectionIntro>
+      )}
       <SectionTitle>課程評價</SectionTitle>
       <CommentsContainer>
-        <CommentCard
-          imgSrc={student1}
-          name="小豪"
-          content="課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。"
-        />
-        <CommentCard
-          imgSrc={student2}
-          name="小葵"
-          content="課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。"
-        />
-        <CommentCard
-          imgSrc={student3}
-          name="小花"
-          content="課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。"
-        />
+        {comments && comments.length !== 0 ? (
+          comments.map((comment) => (
+            <CommentCard
+              imgSrc={comment.imgSrc}
+              name={comment.username}
+              content={comment.content}
+            />
+          ))
+        ) : (
+          <NoStatusText>目前沒有任何評論</NoStatusText>
+        )}
       </CommentsContainer>
     </TeacherProfileWrapper>
   );

--- a/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
+++ b/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { useParams } from "react-router";
 import Avatar from "../../components/Avatar";
-import TeacherManageCalendar from "../../components/Calendar/TeacherManageCalendar";
+import FrontCourseCalendar from "./components/FrontCourseCalendar";
 import teacher from "../../img/teacher.jpeg";
 import student1 from "../../img/student1.png";
 import student2 from "../../img/student2.jpeg";
@@ -9,7 +9,10 @@ import student3 from "../../img/student3.jpeg";
 import CommentCard from "./components/CommentCard";
 
 const TeacherProfileWrapper = styled.section`
-  padding: 196px 100px 232px 120px;
+  padding: 196px 350px 232px 350px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;
 
 const RowContainer = styled.div`
@@ -26,7 +29,9 @@ const TeacherInfosContainer = styled(ColumnContainer)`
   width: 200px;
 `;
 
-const TeacherProfileContainer = styled(RowContainer)``;
+const TeacherProfileContainer = styled(RowContainer)`
+  justify-content: center;
+`;
 
 const CourseInfosContainer = styled(ColumnContainer)`
   border: 2px solid ${(props) => props.theme.colors.orange};
@@ -34,6 +39,7 @@ const CourseInfosContainer = styled(ColumnContainer)`
   color: ${(props) => props.theme.colors.grey_dark};
   margin-top: 20px;
   padding: 15px;
+  min-width: 200px;
 `;
 
 const ItemContainer = styled(ColumnContainer)`
@@ -88,7 +94,7 @@ function FrontCoursePage() {
             </ItemContainer>
           </CourseInfosContainer>
         </TeacherInfosContainer>
-        <TeacherManageCalendar teacherId={teacherId} />
+        <FrontCourseCalendar teacherId={teacherId} />
       </TeacherProfileContainer>
       <SectionTitle>課程介紹</SectionTitle>
       <SectionIntro>

--- a/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
+++ b/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
@@ -6,7 +6,7 @@ import teacher from "../../img/teacher.jpeg";
 import student1 from "../../img/student1.png";
 import student2 from "../../img/student2.jpeg";
 import student3 from "../../img/student3.jpeg";
-import CommentCard from "./CommentCard";
+import CommentCard from "./components/CommentCard";
 
 const TeacherProfileWrapper = styled.section`
   padding: 196px 100px 232px 120px;
@@ -66,7 +66,7 @@ const SectionIntro = styled(ItemContent)`
 
 const CommentsContainer = styled(ColumnContainer)``;
 
-function TeacherProfilePage() {
+function FrontCoursePage() {
   const { teacherId } = useParams();
   return (
     <TeacherProfileWrapper>
@@ -121,4 +121,4 @@ function TeacherProfilePage() {
   );
 }
 
-export default TeacherProfilePage;
+export default FrontCoursePage;

--- a/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
+++ b/skilfor/src/pages/FrontCoursePage/FrontCoursePage.js
@@ -1,101 +1,113 @@
 import styled from "styled-components";
 import { useParams } from "react-router";
-import Avatar from "../../components/Avatar";
+import { AvatarContainer } from "../../components/Avatar/Avatar";
 import FrontCourseCalendar from "./components/FrontCourseCalendar";
 import teacher from "../../img/teacher.jpeg";
 import student1 from "../../img/student1.png";
 import student2 from "../../img/student2.jpeg";
 import student3 from "../../img/student3.jpeg";
 import CommentCard from "./components/CommentCard";
+import {
+  MEDIA_QUERY_MD,
+  MEDIA_QUERY_SM,
+} from "../../components/constants/breakpoints";
 
 const TeacherProfileWrapper = styled.section`
-  padding: 196px 350px 232px 350px;
+  padding: 180px 200px 232px 200px;
   display: flex;
   flex-direction: column;
   justify-content: center;
+  @media screen and (max-width: 1000px) {
+    padding: 180px 150px 232px 150px;
+  }
+  ${MEDIA_QUERY_MD} {
+    padding: 180px 30px 232px 30px;
+  }
 `;
-
 const RowContainer = styled.div`
   display: flex;
 `;
-
 const ColumnContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
-
-const TeacherInfosContainer = styled(ColumnContainer)`
-  margin-right: 50px;
-  width: 200px;
-`;
-
-const TeacherProfileContainer = styled(RowContainer)`
+const TeacherAvatarContainer = styled(ColumnContainer)`
+  align-items: center;
   justify-content: center;
+  margin-right: 50px;
 `;
-
-const CourseInfosContainer = styled(ColumnContainer)`
-  border: 2px solid ${(props) => props.theme.colors.orange};
-  border-radius: 10px;
+const TeacherAvatar = styled(AvatarContainer)`
+  width: 150px;
+  height: 150px;
+`;
+const AvatarName = styled.p`
   color: ${(props) => props.theme.colors.grey_dark};
-  margin-top: 20px;
-  padding: 15px;
-  min-width: 200px;
+  font-size: 1.2rem;
+  margin-top: 12px;
 `;
-
+const TeacherInfosContainer = styled(RowContainer)`
+  justify-content: center;
+  align-items: center;
+  ${MEDIA_QUERY_SM} {
+    flex-direction: column;
+  }
+`;
+const CourseInfosContainer = styled(ColumnContainer)`
+  color: ${(props) => props.theme.colors.grey_dark};
+  margin-left: 15px;
+  width: 100%;
+`;
 const ItemContainer = styled(ColumnContainer)`
-  border-bottom: 2px solid ${(props) => props.theme.colors.orange};
+  border-bottom: 2px dotted ${(props) => props.theme.colors.orange};
   margin-bottom: 20px;
 `;
-
 const ItemTitle = styled.h3`
   color: ${(props) => props.theme.colors.orange};
   font-size: 1.1rem;
   margin-bottom: 2px;
 `;
-
 const ItemContent = styled.p`
   color: ${(props) => props.theme.colors.grey_dark};
   font-size: 1rem;
   padding-left: 5px;
   margin-bottom: 5px;
 `;
-
 const SectionTitle = styled.h1`
   color: ${(props) => props.theme.colors.green_dark};
   font-size: 1.5rem;
   margin: 40px 0 10px 0;
 `;
-
 const SectionIntro = styled(ItemContent)`
   font-size: 1.1rem;
 `;
-
 const CommentsContainer = styled(ColumnContainer)``;
 
 function FrontCoursePage() {
-  const { teacherId } = useParams();
+  const { courseId } = useParams();
   return (
     <TeacherProfileWrapper>
-      <TeacherProfileContainer>
-        <TeacherInfosContainer>
-          <Avatar imgSrc={teacher} name="Kelly" />
-          <CourseInfosContainer>
-            <ItemContainer>
-              <ItemTitle>領域</ItemTitle>
-              <ItemContent>程式</ItemContent>
-            </ItemContainer>
-            <ItemContainer>
-              <ItemTitle>課程名稱</ItemTitle>
-              <ItemContent>一起來學習超潮的 Ruby 吧！</ItemContent>
-            </ItemContainer>
-            <ItemContainer>
-              <ItemTitle>單堂價格</ItemTitle>
-              <ItemContent>1000</ItemContent>
-            </ItemContainer>
-          </CourseInfosContainer>
-        </TeacherInfosContainer>
-        <FrontCourseCalendar teacherId={teacherId} />
-      </TeacherProfileContainer>
+      <TeacherInfosContainer>
+        <TeacherAvatarContainer>
+          <TeacherAvatar imgSrc={teacher} name="Kelly" />
+          <AvatarName>Kelly</AvatarName>
+        </TeacherAvatarContainer>
+        <CourseInfosContainer>
+          <ItemContainer>
+            <ItemTitle>領域</ItemTitle>
+            <ItemContent>程式</ItemContent>
+          </ItemContainer>
+          <ItemContainer>
+            <ItemTitle>課程名稱</ItemTitle>
+            <ItemContent>一起來學習超潮的 Ruby 吧！</ItemContent>
+          </ItemContainer>
+          <ItemContainer>
+            <ItemTitle>單堂價格</ItemTitle>
+            <ItemContent>1000</ItemContent>
+          </ItemContainer>
+        </CourseInfosContainer>
+      </TeacherInfosContainer>
+      <SectionTitle>課程時間</SectionTitle>
+      <FrontCourseCalendar courseId={courseId} />
       <SectionTitle>課程介紹</SectionTitle>
       <SectionIntro>
         經過幾年的發展，Spring Boot

--- a/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
+++ b/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
@@ -13,7 +13,7 @@ const ColumnContainer = styled.div`
 const CommentCardContainer = styled(RowContainer)`
   align-items: center;
   justify-content: center;
-  border: 2px solid ${(props) => props.theme.colors.orange};
+  border: 1px solid ${(props) => props.theme.colors.green_dark};
   border-radius: 10px;
   padding: 20px;
   :first-child {

--- a/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
+++ b/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { AvatarContainer } from "../../components/Avatar/Avatar";
+import { AvatarContainer } from "../../../components/Avatar/Avatar";
 
 const RowContainer = styled.div`
   display: flex;

--- a/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
+++ b/skilfor/src/pages/FrontCoursePage/components/CommentCard.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { AvatarContainer } from "../../../components/Avatar/Avatar";
+import { MEDIA_QUERY_SM } from "../../../components/constants/breakpoints";
 
 const RowContainer = styled.div`
   display: flex;
@@ -15,12 +16,15 @@ const CommentCardContainer = styled(RowContainer)`
   justify-content: center;
   border: 1px solid ${(props) => props.theme.colors.green_dark};
   border-radius: 10px;
-  padding: 20px;
+  padding: 25px;
   :first-child {
     margin-top: 20px;
   }
   :not(:last-child) {
     margin-bottom: 25px;
+  }
+  ${MEDIA_QUERY_SM} {
+    flex-direction: column;
   }
 `;
 
@@ -29,6 +33,9 @@ const CommentContent = styled.p`
   margin-left: 20px;
   line-height: 1.8rem;
   font-size: 1.1rem;
+  ${MEDIA_QUERY_SM} {
+    margin-top: 20px;
+  }
 `;
 
 const StudentInfosContainer = styled(ColumnContainer)`

--- a/skilfor/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
+++ b/skilfor/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { Calendar, momentLocalizer } from "react-big-calendar";
+import moment from "moment";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import ReserveAlertCard from "./ReserveAlertCard";
+import { COURSE_EVENT_LIST } from "../constants";
+import { sleep } from "../../../utils";
+
+const CalendarContainer = styled.div`
+  position: relative;
+`;
+function FrontCourseCalendar({ courseId }) {
+  const localizer = momentLocalizer(moment);
+  const [alertShow, setAlertShow] = useState(false);
+  const [allEvents, setAllEvents] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(false);
+  const [currentPage, setCurrentPage] = useState(new Date());
+  useEffect(() => {
+    async function fetchData() {
+      await sleep(100);
+      COURSE_EVENT_LIST.map((event) => {
+        event.resource.courseName = event.title;
+        event.title = event.resource.timePeriod;
+        return event;
+      });
+      setAllEvents(COURSE_EVENT_LIST);
+    }
+    fetchData();
+  }, []);
+
+  const handleEventClick = (e) => {
+    setAlertShow("read");
+    console.log(e);
+    setSelectedEvent(e);
+  };
+
+  const eventStyleGetter = (event) => {
+    var eventColor = event.resource.eventColor;
+
+    var style = {
+      border: `2px solid ${eventColor}`,
+      backgroundColor: "white",
+      color: "black",
+      fontSize: "14px",
+    };
+    return {
+      style: style,
+    };
+  };
+
+  const handlePageChange = (currentMonthPage) => {
+    setCurrentPage(currentMonthPage);
+  };
+
+  return (
+    <CalendarContainer>
+      <Calendar
+        onSelectEvent={handleEventClick}
+        selectable
+        localizer={localizer}
+        startAccessor="start"
+        endAccessor="end"
+        style={{ width: "1000px", height: "500px" }}
+        events={allEvents}
+        views={["month"]}
+        onNavigate={handlePageChange}
+        date={currentPage}
+        eventPropGetter={eventStyleGetter}
+      />
+      {alertShow === "read" && (
+        <ReserveAlertCard
+          setAllEvents={setAllEvents}
+          allEvents={allEvents}
+          alertShow={alertShow}
+          setAlertShow={setAlertShow}
+          selectedEvent={selectedEvent}
+        />
+      )}
+    </CalendarContainer>
+  );
+}
+
+export default FrontCourseCalendar;

--- a/skilfor/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
+++ b/skilfor/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
@@ -9,6 +9,9 @@ import { sleep } from "../../../utils";
 
 const CalendarContainer = styled.div`
   position: relative;
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
 `;
 function FrontCourseCalendar({ courseId }) {
   const localizer = momentLocalizer(moment);
@@ -31,18 +34,16 @@ function FrontCourseCalendar({ courseId }) {
 
   const handleEventClick = (e) => {
     setAlertShow("read");
-    console.log(e);
     setSelectedEvent(e);
   };
 
   const eventStyleGetter = (event) => {
     var eventColor = event.resource.eventColor;
-
     var style = {
       border: `2px solid ${eventColor}`,
       backgroundColor: "white",
       color: "black",
-      fontSize: "14px",
+      fontSize: "12px",
     };
     return {
       style: style,
@@ -61,7 +62,7 @@ function FrontCourseCalendar({ courseId }) {
         localizer={localizer}
         startAccessor="start"
         endAccessor="end"
-        style={{ width: "1000px", height: "500px" }}
+        style={{ width: "100vw", height: "600px" }}
         events={allEvents}
         views={["month"]}
         onNavigate={handlePageChange}

--- a/skilfor/src/pages/FrontCoursePage/components/ReserveAlertCard.js
+++ b/skilfor/src/pages/FrontCoursePage/components/ReserveAlertCard.js
@@ -1,0 +1,52 @@
+import styled from "styled-components";
+import {
+  AlertContainer,
+  AlertTitle,
+  AlertContent,
+  AlertButton,
+  CloseButton,
+} from "../../../components/Calendar/AddTaskAlertCard";
+import close from "../../../img/close.png";
+
+const ContentContainer = styled.div``;
+
+const WrapContent = styled(AlertContent)`
+  overflow-wrap: break-word;
+`;
+const getDisplayDate = (dateObj) => {
+  let dateStr = dateObj.toLocaleString();
+  return dateStr.slice(0, dateStr.length - 3);
+};
+
+function ReserveAlertCard({
+  allEvents,
+  setAllEvents,
+  setAlertShow,
+  selectedEvent,
+}) {
+  const handleCloseClick = () => {
+    setAlertShow(null);
+  };
+  const handleReserveEvent = () => {
+    //打加入購物車 API
+    alert("加入成功！");
+    setAlertShow(false);
+  };
+  return (
+    <AlertContainer color="#75A29E">
+      <CloseButton src={close} onClick={handleCloseClick} />
+      <AlertTitle>
+        {selectedEvent.resource.courseName} <br />
+        {getDisplayDate(selectedEvent.start)}
+      </AlertTitle>
+      <WrapContent>
+        溫馨提醒：加入購物車不代表預約成功，請至購物車完成扣點手續，我們才能幫你保留這堂課程喔！
+      </WrapContent>
+      <AlertButton color="#75A29E" onClick={handleReserveEvent}>
+        加入購物車
+      </AlertButton>
+    </AlertContainer>
+  );
+}
+
+export default ReserveAlertCard;

--- a/skilfor/src/pages/FrontCoursePage/components/ReserveAlertCard.js
+++ b/skilfor/src/pages/FrontCoursePage/components/ReserveAlertCard.js
@@ -8,8 +8,6 @@ import {
 } from "../../../components/Calendar/AddTaskAlertCard";
 import close from "../../../img/close.png";
 
-const ContentContainer = styled.div``;
-
 const WrapContent = styled(AlertContent)`
   overflow-wrap: break-word;
 `;

--- a/skilfor/src/pages/FrontCoursePage/constants.js
+++ b/skilfor/src/pages/FrontCoursePage/constants.js
@@ -1,3 +1,23 @@
+import student1 from "../../img/student1.png";
+import student2 from "../../img/student2.jpeg";
+import student3 from "../../img/student3.jpeg";
+import teacher from "../../img/teacher.jpeg";
+
+export const TEACHER_INFOS = {
+  username: "Kelly",
+  avatar: teacher,
+};
+
+export const COURSE_INFOS = {
+  category: "程式",
+  courseName: "一起來學習超潮的 Ruby 吧！",
+  courseDescription:
+    "經過幾年的發展，Spring Boot 的功能已經非常成熟，並且在近幾年軟體業盛行微服務（microservice）的設計模式下，也帶動越來越多企業選擇使用 Spring Boot 作為主流的開發工具。Spring Boot 之所以能夠成為目前業界最流行的開發工具，原因就在於 Spring Boot 憑借著 簡化 Spring 開發 以及 快速整合主流框架 的優點，讓工程師們可以更專注的在解決問題上，進而提升了前期開發和後續部署的效率。",
+  price: 1000,
+  published: true,
+  audit: "success",
+};
+
 export const COURSE_EVENT_LIST = [
   {
     title: "一起來學習超潮的 Ruby 吧！",
@@ -58,5 +78,26 @@ export const COURSE_EVENT_LIST = [
       timePeriod: "22:30 ~ 23:00",
     },
     id: "Plisyjyva2EPNFXJbTUUs",
+  },
+];
+
+export const COMMENTS = [
+  {
+    imgSrc: student1,
+    username: "小豪",
+    content:
+      "課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。",
+  },
+  {
+    imgSrc: student2,
+    username: "小葵",
+    content:
+      "課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。",
+  },
+  {
+    imgSrc: student3,
+    username: "小花",
+    content:
+      "課程將SQL的語法結構邏輯以及重要語法的功能與使用觀念，以非常循序漸進的主題節奏來教學，讓我能逐步由淺入深地建構對SQL重點觀念的理解，原本自己對於SQL有些粗淺的認識、但對於實際運用時的語法運作邏輯並不是那麼有把握，經過課程系統性的教學、以及每章節課後練習題立即的複習、演練、體驗該章節語法的運作邏輯，讓我釐清許多過去常常不知其所以然的語法邏輯卡關，實際演練練習題不僅能從做中學也讓人很有成就感，有動力及信心繼續深入學習。",
   },
 ];

--- a/skilfor/src/pages/FrontCoursePage/constants.js
+++ b/skilfor/src/pages/FrontCoursePage/constants.js
@@ -1,0 +1,62 @@
+export const COURSE_EVENT_LIST = [
+  {
+    title: "一起來學習超潮的 Ruby 吧！",
+    start: new Date(2021, 11, 12, 1, 30),
+    end: new Date(2021, 11, 12, 2, 0),
+    resource: {
+      reserved: false,
+      studentNotes: null,
+      eventColor: "#22577A",
+      timePeriod: "1:30 ~ 2:00",
+    },
+    id: "Plisyjyva2EPNFXJbTUUs",
+  },
+  {
+    title: "一起來學習超潮的 Ruby 吧！",
+    start: new Date(2021, 11, 13, 1, 30),
+    end: new Date(2021, 11, 13, 2, 0),
+    resource: {
+      reserved: false,
+      studentNotes: null,
+      eventColor: "#22577A",
+      timePeriod: "1:30 ~ 2:00",
+    },
+    id: "Hql9epDk2ladMYomuXv5C",
+  },
+  {
+    title: "一起來學習超潮的 Ruby 吧！",
+    start: new Date(2021, 11, 14, 1, 30),
+    end: new Date(2021, 11, 14, 2, 0),
+    resource: {
+      reserved: false,
+      studentNotes: null,
+      eventColor: "#22577A",
+      timePeriod: "1:30 ~ 2:00",
+    },
+    id: "T-dzEKLxfThGJWsjsV0fw",
+  },
+  {
+    title: "一起來學習超潮的 Ruby 吧！",
+    start: new Date(2021, 11, 12, 10, 30),
+    end: new Date(2021, 11, 12, 11, 0),
+    resource: {
+      reserved: false,
+      studentNotes: null,
+      eventColor: "#22577A",
+      timePeriod: "10:30 ~ 11:00",
+    },
+    id: "Plisyjyva2EPNFXJbTUUs",
+  },
+  {
+    title: "一起來學習超潮的 Ruby 吧！",
+    start: new Date(2021, 11, 20, 22, 30),
+    end: new Date(2021, 11, 20, 23, 0),
+    resource: {
+      reserved: false,
+      studentNotes: null,
+      eventColor: "#22577A",
+      timePeriod: "22:30 ~ 23:00",
+    },
+    id: "Plisyjyva2EPNFXJbTUUs",
+  },
+];

--- a/skilfor/src/pages/FrontCoursePage/index.js
+++ b/skilfor/src/pages/FrontCoursePage/index.js
@@ -1,0 +1,2 @@
+import FrontCoursePage from "./FrontCoursePage";
+export default FrontCoursePage;

--- a/skilfor/src/pages/TeacherCalendarPage/TeacherCalendarPage.js
+++ b/skilfor/src/pages/TeacherCalendarPage/TeacherCalendarPage.js
@@ -2,9 +2,14 @@ import TeacherManageCalendar from "../../components/Calendar/TeacherManageCalend
 import styled from "styled-components";
 import PageTitle from "../../components/PageTitle";
 import { useParams } from "react-router";
+import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 
 const TeacherCalendarWrapper = styled.section`
-  padding: 186px 100px 232px 100px;
+  padding: 166px 50px 232px 50px;
+  ${MEDIA_QUERY_SM} {
+    padding: 150px 10px 130px 10px;
+    text-align: center;
+  }
 `;
 
 function TeacherCalendarPage() {

--- a/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CategoryDropDownMenu.js
@@ -10,6 +10,7 @@ const SelectContainer = styled(RowContainer)`
   margin-bottom: 20px;
 `;
 const SelectBar = styled.select`
+  background: white;
   padding: 5px;
   font-size: 1rem;
   border: 1px solid ${(props) => props.theme.colors.grey_dark};

--- a/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/skilfor/src/pages/TeacherManagePage/components/CoursePage.js
@@ -78,7 +78,7 @@ const CourseButton = styled.button`
     props.isClick &&
     `background: ${props.theme.colors.green_dark}; color:white; border:2px solid ${props.theme.colors.green_dark}`}
 `;
-const GoToCalendar = styled(Link)`
+const GoToLink = styled(Link)`
   color: ${(props) => props.theme.colors.grey_dark};
   cursor: pointer;
   text-decoration: none;
@@ -288,9 +288,9 @@ function CoursePage({ apiError, setApiError }) {
                 </PassContainer>
               </SuccessContainer>
               <SectionText>設定課程時段</SectionText>
-              <GoToCalendar to={`/teacher/calendar/${teacherId}`}>
+              <GoToLink to={`/teacher/calendar/${teacherId}`}>
                 前往行事曆設定課程時段 ➜
-              </GoToCalendar>
+              </GoToLink>
             </>
           )}
           {selectedCourseInfos.audit === "pending" && (
@@ -355,6 +355,14 @@ function CoursePage({ apiError, setApiError }) {
                 handleRadioChange={handleRadioChange}
                 published={selectedCourseInfos.published}
               />
+            </>
+          )}
+          {selectedCourseInfos.published && (
+            <>
+              <SectionText>瀏覽我的前台頁面</SectionText>
+              <GoToLink to={`/course/${selectedCourseInfos.id}`}>
+                前往此門課程的前台頁面 ➜
+              </GoToLink>
             </>
           )}
         </>

--- a/skilfor/src/pages/TeacherProfilePage/index.js
+++ b/skilfor/src/pages/TeacherProfilePage/index.js
@@ -1,2 +1,0 @@
-import TeacherProfilePage from "./TeacherProfilePage";
-export default TeacherProfilePage;


### PR DESCRIPTION
### Context
1. 老師後台行事曆頁面 RWD
2. 課程前台頁面 UI 優化，原本的我覺得有點不好看且很難 RWD，然後加上 RWD
3. 老師後台課程頁面：若老師課程為發布前台狀態，則顯示導向前台的連結
4. 新增課程前台行事曆 component（給學生看課程時間和預約課程用），點擊行程會顯示是否加入購物車訊息
5. 課程前台：新增 API 假資料，等之後 API 開好就直接串上去