### PR TITLE
行事曆行程顯示調整 ＆ 修復行事曆 more 無法顯示的 bug

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -241,7 +241,6 @@ export const getCalendarMonthEvents = async (setApiError, month) => {
 export const addNewCalendarEvent = async (setApiError, newEvent) => {
   let url = `${BASE_URL}/teacher/calendar`;
   const token = getAuthToken();
-  console.log(newEvent);
   try {
     const res = await fetch(url, {
       method: "POST",
@@ -300,7 +299,6 @@ export const getStudentCalendarMonthEvents = async (setApiError, month) => {
   }
 };
 export const cancelStudentCalendarEvent = async (setApiError, scheduleId) => {
-  console.log(scheduleId);
   let url = encodeURI(`${BASE_URL}/student/calendar`);
   const token = getAuthToken();
   try {

--- a/src/components/Calendar/AddTaskAlertCard.js
+++ b/src/components/Calendar/AddTaskAlertCard.js
@@ -4,12 +4,7 @@ import { useNavigate } from "react-router-dom";
 import close from "../../img/close.png";
 import { nanoid } from "nanoid";
 import { TIME_OPTIONS, COLOR_HEX_LIST } from "./constants";
-import {
-  createTimeOptions,
-  getDay,
-  getTimeNumber,
-  checkEventsConflict,
-} from "./utils";
+import { getDay, getTimeNumber, checkEventsConflict } from "./utils";
 import { addNewCalendarEvent } from "../../WebAPI";
 
 //styled component
@@ -100,7 +95,7 @@ function AddTaskAlertCard({
   const [newEvent, setNewEvent] = useState({
     title: courseList.length === 0 ? null : courseList[0].courseName,
     start: "上午0:00",
-    end: "上午0:30",
+    end: "上午1:00",
     resource: {
       reserved: false,
       studentNotes: null,
@@ -124,19 +119,19 @@ function AddTaskAlertCard({
       });
     }
     if (id === "start") {
-      let endTime = TIME_OPTIONS[TIME_OPTIONS.indexOf(value) + 1];
+      let endTime = TIME_OPTIONS[TIME_OPTIONS.indexOf(value) + 2];
       setNewEvent({
         ...newEvent,
         start: value,
         end: endTime,
       });
     }
-    if (id === "end") {
-      setNewEvent({
-        ...newEvent,
-        end: value,
-      });
-    }
+    // if (id === "end") {
+    //   setNewEvent({
+    //     ...newEvent,
+    //     end: value,
+    //   });
+    // }
     if (id === "eventColor") {
       setNewEvent({
         ...newEvent,
@@ -189,7 +184,6 @@ function AddTaskAlertCard({
         timePeriod: `${start} ~ ${end}`,
       },
     };
-    console.log(postData);
     addNewCalendarEvent(setApiError, postData).then((json) => {
       if (!json || !json.success) {
         setAlertShow(null);
@@ -233,7 +227,7 @@ function AddTaskAlertCard({
               onChange={handleNewEventAnswerChange}
               value={newEvent.start}
             >
-              {createTimeOptions("start").map((item) => {
+              {TIME_OPTIONS.slice(0, TIME_OPTIONS.length - 2).map((item) => {
                 return (
                   <SelectOption key={nanoid()} value={item.id}>
                     {item}
@@ -244,7 +238,8 @@ function AddTaskAlertCard({
           </RowContainer>
           <RowContainer>
             <AlertContent>結束時間：</AlertContent>
-            <SelectContainer
+            <AlertContent>{newEvent.end}</AlertContent>
+            {/* <SelectContainer
               id="end"
               onChange={handleNewEventAnswerChange}
               value={newEvent.end}
@@ -252,7 +247,7 @@ function AddTaskAlertCard({
               {createTimeOptions("end", newEvent.start).map((item) => {
                 return <SelectOption key={nanoid()}>{item}</SelectOption>;
               })}
-            </SelectContainer>
+            </SelectContainer> */}
           </RowContainer>
           <RowContainer>
             <AlertContent>設定活動顏色：</AlertContent>

--- a/src/components/Calendar/ReadTaskAlertCard.js
+++ b/src/components/Calendar/ReadTaskAlertCard.js
@@ -20,7 +20,6 @@ const WrapContent = styled(AlertContent)`
 `;
 const getDisplayDate = (dateObj) => {
   let dateStr = dateObj.toLocaleString();
-  console.log(dateStr);
   return dateStr.slice(0, dateStr.length - 3);
 };
 
@@ -31,7 +30,6 @@ function ReadTaskAlertCard({
   selectedEvent,
   setApiError,
 }) {
-  console.log(selectedEvent);
   const handleCloseClick = () => {
     setAlertShow(null);
   };

--- a/src/components/Calendar/ReadTaskAlertCard.js
+++ b/src/components/Calendar/ReadTaskAlertCard.js
@@ -35,8 +35,15 @@ function ReadTaskAlertCard({
   const handleCloseClick = () => {
     setAlertShow(null);
   };
-  const handleDeleteEvent = () => {
-    let confirmAlert = window.confirm("確定刪除此時段的課程嗎？");
+  const handleDeleteEvent = (selectedEvent) => {
+    let confirmAlert;
+    if (selectedEvent.resource.reserved) {
+      confirmAlert = window.confirm(
+        "確定取消此時段的課程嗎？系統將通知預約的學生您已取消這堂課！"
+      );
+    } else {
+      confirmAlert = window.confirm("確定刪除此時段的課程嗎？");
+    }
     if (!confirmAlert) return;
     deleteCalendarEvent(setApiError, selectedEvent.id).then((json) => {
       if (!json || !json.success) return setApiError("課程時間刪除失敗");
@@ -65,11 +72,12 @@ function ReadTaskAlertCard({
             學生備註：{selectedEvent.resource.studentNotes}
           </WrapContent>
         )}
-        {!selectedEvent.resource.reserved && (
-          <AlertButton color="#75A29E" onClick={handleDeleteEvent}>
-            刪除此時段
-          </AlertButton>
-        )}
+        <AlertButton
+          color="#75A29E"
+          onClick={() => handleDeleteEvent(selectedEvent)}
+        >
+          {selectedEvent.resource.reserved ? "取消此時段" : "刪除此時段"}
+        </AlertButton>
       </ContentContainer>
     </AlertContainer>
   );

--- a/src/components/Calendar/StudentManageCalendar.js
+++ b/src/components/Calendar/StudentManageCalendar.js
@@ -51,10 +51,7 @@ function StudentManageCalendar() {
   const eventStyleGetter = (event) => {
     var eventColor = event.resource.eventColor;
     let style;
-    if (
-      new Date(event.start).getTime() < new Date().getTime() ||
-      !event.exist
-    ) {
+    if (new Date(event.end).getTime() < new Date().getTime() || !event.exist) {
       style = {
         border: `2px solid #e6e6e6`,
         backgroundColor: "#e6e6e6",

--- a/src/components/Calendar/StudentManageCalendar.js
+++ b/src/components/Calendar/StudentManageCalendar.js
@@ -51,7 +51,10 @@ function StudentManageCalendar() {
   const eventStyleGetter = (event) => {
     var eventColor = event.resource.eventColor;
     let style;
-    if (new Date(event.start).getTime() < new Date().getTime()) {
+    if (
+      new Date(event.start).getTime() < new Date().getTime() ||
+      !event.exist
+    ) {
       style = {
         border: `2px solid #e6e6e6`,
         backgroundColor: "#e6e6e6",

--- a/src/components/Calendar/StudentReadTaskCard.js
+++ b/src/components/Calendar/StudentReadTaskCard.js
@@ -44,21 +44,31 @@ function StudentReadTaskCard({
         <TimeTitle>結束：{getDisplayDate(selectedEvent.end)}</TimeTitle>
       </TimeContainer>
       <ContentContainer>
-        <AlertContent>
-          <NoneStyleLink to={`/course/${selectedEvent.courseId}`}>
-            瀏覽此課程頁面 ➜
-          </NoneStyleLink>
-        </AlertContent>
-        <AlertContent>
-          課程視訊連結：https://explore.zoom.us/zh-tw/products/meetings/
-        </AlertContent>
-        {selectedEvent.start.getTime() - new Date().getTime() > 86400000 && (
-          <AlertButton
-            color="#75A29E"
-            onClick={() => handleCancelEvent(selectedEvent.id)}
-          >
-            取消此時段
-          </AlertButton>
+        {selectedEvent.exist && (
+          <>
+            <AlertContent>
+              <NoneStyleLink to={`/course/${selectedEvent.courseId}`}>
+                瀏覽此課程頁面 ➜
+              </NoneStyleLink>
+            </AlertContent>
+            <AlertContent>
+              課程視訊連結：https://explore.zoom.us/zh-tw/products/meetings/
+            </AlertContent>
+            {selectedEvent.start.getTime() - new Date().getTime() >
+              86400000 && (
+              <AlertButton
+                color="#75A29E"
+                onClick={() => handleCancelEvent(selectedEvent.id)}
+              >
+                取消此時段
+              </AlertButton>
+            )}
+          </>
+        )}
+        {!selectedEvent.exist && (
+          <AlertContent>
+            老師臨時無法上課，因此取消了此堂課程，系統已經自動將點數退還給你囉！
+          </AlertContent>
         )}
       </ContentContainer>
     </AlertContainer>

--- a/src/components/Calendar/TeacherManageCalendar.js
+++ b/src/components/Calendar/TeacherManageCalendar.js
@@ -78,20 +78,30 @@ function TeacherManageCalendar() {
     var eventColor = event.resource.eventColor;
     var reserved = event.resource.reserved;
     var style;
-    if (!reserved) {
+    if (new Date(event.end).getTime() < new Date().getTime()) {
       style = {
-        border: `2px solid ${eventColor}`,
-        backgroundColor: "white",
-        color: "black",
-        fontSize: "14px",
+        border: `2px solid #e6e6e6`,
+        backgroundColor: "#e6e6e6",
+        color: "#AAAAAA",
+        fontSize: "12px",
       };
     } else {
-      style = {
-        border: `2px solid ${eventColor}`,
-        backgroundColor: eventColor,
-        color: "white",
-        fontSize: "14px",
-      };
+      if (!reserved) {
+        style = {
+          border: `2px solid ${eventColor}`,
+          backgroundColor: "white",
+          color: "black",
+          fontSize: "14px",
+        };
+      }
+      if (reserved) {
+        style = {
+          border: `2px solid ${eventColor}`,
+          backgroundColor: eventColor,
+          color: "white",
+          fontSize: "14px",
+        };
+      }
     }
     return {
       style: style,

--- a/src/components/Calendar/utils.js
+++ b/src/components/Calendar/utils.js
@@ -4,7 +4,7 @@ import { TIME_OPTIONS } from "./constants";
 export const createTimeOptions = (timeType, time) => {
   //沒給定開始時間的結束時間選單
   if (!time && timeType === "end") {
-    let endOptions = TIME_OPTIONS.slice(1, TIME_OPTIONS.length);
+    let endOptions = TIME_OPTIONS.slice(2, TIME_OPTIONS.length);
     return endOptions;
   }
   //給定開始時間的結束時間選單

--- a/src/pages/FrontCoursePage/FrontCoursePage.js
+++ b/src/pages/FrontCoursePage/FrontCoursePage.js
@@ -3,12 +3,12 @@ import styled from "styled-components";
 import { useParams } from "react-router";
 import { AvatarContainer } from "../../components/Avatar/Avatar";
 import FrontCourseCalendar from "./components/FrontCourseCalendar";
-import CommentCard from "./components/CommentCard";
+// import CommentCard from "./components/CommentCard";
 import {
   MEDIA_QUERY_MD,
   MEDIA_QUERY_SM,
 } from "../../components/constants/breakpoints";
-import { nanoid } from "nanoid";
+// import { nanoid } from "nanoid";
 import AlertCard from "../../components/AlertCard";
 import { getFrontCourseInfos } from "../../WebAPI";
 
@@ -85,17 +85,17 @@ const SectionIntro = styled(ItemContent)`
   font-size: 1.1rem;
   white-space: pre-wrap;
 `;
-const CommentsContainer = styled(ColumnContainer)``;
-const NoStatusText = styled.p`
-  color: ${(props) => props.theme.colors.grey_dark};
-  font-size: 1.2rem;
-`;
+// const CommentsContainer = styled(ColumnContainer)``;
+// const NoStatusText = styled.p`
+//   color: ${(props) => props.theme.colors.grey_dark};
+//   font-size: 1.2rem;
+// `;
 
 function FrontCoursePage() {
   window.scroll(0, 0);
   const { courseId } = useParams();
   const [infos, setInfos] = useState(null);
-  const [comments, setComments] = useState(null);
+  // const [comments, setComments] = useState(null);
   const [apiError, setApiError] = useState(null);
   //拿老師與課程資訊資料
   useEffect(() => {
@@ -151,8 +151,8 @@ function FrontCoursePage() {
       <FrontCourseCalendar courseId={courseId} />
       <SectionTitle>課程介紹</SectionTitle>
       {infos && <SectionIntro>{infos.courseDescription}</SectionIntro>}
-      <SectionTitle>課程評價</SectionTitle>
-      <CommentsContainer>
+      {/* <SectionTitle>課程評價</SectionTitle> */}
+      {/* <CommentsContainer>
         {comments && comments.length !== 0 ? (
           comments.map((comment) => (
             <CommentCard
@@ -165,7 +165,7 @@ function FrontCoursePage() {
         ) : (
           <NoStatusText>目前沒有任何評論</NoStatusText>
         )}
-      </CommentsContainer>
+      </CommentsContainer> */}
     </TeacherProfileWrapper>
   );
 }

--- a/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
+++ b/src/pages/FrontCoursePage/components/FrontCourseCalendar.js
@@ -38,8 +38,15 @@ function FrontCourseCalendar({ courseId }) {
         setLoading(false);
         return setApiError("發生了一點錯誤，請稍後再試");
       }
-      setAllEvents(json.data);
-      setLoading(false);
+      if (json.data) {
+        let eventsData = json.data.map((event) => {
+          event.start = new Date(event.start);
+          event.end = new Date(event.end);
+          return event;
+        });
+        setAllEvents(eventsData);
+        setLoading(false);
+      }
     }
     fetchData();
   }, [courseId, setApiError, currentPage]);
@@ -115,7 +122,7 @@ function FrontCourseCalendar({ courseId }) {
         endAccessor="end"
         style={{ width: "100vw", height: "600px" }}
         events={allEvents}
-        views={["month"]}
+        views={["month", "day", "week"]}
         onNavigate={handlePageChange}
         date={currentPage}
         eventPropGetter={eventStyleGetter}


### PR DESCRIPTION
### Context
1. 新增老師取消課程功能 & 老師取消課程後學生行事曆 UI 調整(學生看到的行程會變成灰底，並且會在卡片上告知學生老師已取消課程)
2. 修復課程前台頁面行事曆 more 無法正常顯示的問題
3. 將新增課程時段卡片的課程時段選項改為一小時(將結束時間選單拔掉，只能選開始時間，結束時間自動會是開始時間的後一小時）
4. 將老師行事曆過期行程改為灰底顯示，避免與有效行程搞混