### PR TITLE
點數儲值頁面串綠界金流 & 新增學生刪除過期行程功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "crypto-js": "^4.1.1",
     "gh-pages": "^3.2.3",
     "moment": "^2.29.1",
     "nanoid": "^3.1.30",

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -300,9 +300,33 @@ export const getStudentCalendarMonthEvents = async (setApiError, month) => {
 export const cancelStudentCalendarEvent = async (setApiError, scheduleId) => {
   let url = encodeURI(`${BASE_URL}/student/calendar`);
   const token = getAuthToken();
+  console.log(scheduleId);
   try {
     const res = await fetch(url, {
       method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        scheduleId: scheduleId,
+      }),
+    });
+    console.log(await res.json());
+    if (!res.ok) throw new Error("fail to cancel event");
+    return await res.json();
+  } catch (error) {
+    setApiError("發生了一點錯誤，請稍後再試");
+    return;
+  }
+};
+
+export const deleteStudentCalendarEvent = async (setApiError, scheduleId) => {
+  let url = encodeURI(`${BASE_URL}/student/calendar`);
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "DELETE",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -456,3 +456,25 @@ export const addOrder = async (orderData, setApiError) => {
     return setApiError("目前無法確認購買課程，請稍後再試");
   }
 };
+//點數儲值
+export const getOrderId = async (itemName, price, point) => {
+  let url = `${BASE_URL}/point`;
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        ItemName: itemName,
+        TotalAmount: price,
+        TotalPoint: point,
+      }),
+    });
+    return await res.json();
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -300,7 +300,6 @@ export const getStudentCalendarMonthEvents = async (setApiError, month) => {
 export const cancelStudentCalendarEvent = async (setApiError, scheduleId) => {
   let url = encodeURI(`${BASE_URL}/student/calendar`);
   const token = getAuthToken();
-  console.log(scheduleId);
   try {
     const res = await fetch(url, {
       method: "PUT",
@@ -312,7 +311,6 @@ export const cancelStudentCalendarEvent = async (setApiError, scheduleId) => {
         scheduleId: scheduleId,
       }),
     });
-    console.log(await res.json());
     if (!res.ok) throw new Error("fail to cancel event");
     return await res.json();
   } catch (error) {

--- a/src/components/Calendar/StudentManageCalendar.js
+++ b/src/components/Calendar/StudentManageCalendar.js
@@ -7,6 +7,7 @@ import AlertCard from "../AlertCard";
 import {
   getStudentCalendarMonthEvents,
   cancelStudentCalendarEvent,
+  deleteStudentCalendarEvent,
 } from "../../WebAPI";
 import LoaderSpining from "../../components/LoaderSpining";
 import { CalendarContainer, LoadingSquare } from "./TeacherManageCalendar";
@@ -83,6 +84,18 @@ function StudentManageCalendar() {
       alert("課程取消成功！我們已經將此堂課的課程點數退還給你囉！");
     });
   };
+  const handleDeleteEvent = (eventId) => {
+    let confirm = window.confirm("確認要刪除這筆課程紀錄嗎？");
+    if (!confirm) return;
+    deleteStudentCalendarEvent(setApiError, eventId).then((json) => {
+      if (!json || !json.success) {
+        setLoading(false);
+        return setApiError("目前無法刪除這筆課程紀錄，請稍後再試");
+      }
+      setAlertShow(false);
+      setAllEvents(allEvents.filter((event) => event.id !== eventId));
+    });
+  };
   return (
     <CalendarContainer>
       {loading && (
@@ -117,6 +130,7 @@ function StudentManageCalendar() {
           setAlertShow={setAlertShow}
           selectedEvent={selectedEvent}
           handleCancelEvent={handleCancelEvent}
+          handleDeleteEvent={handleDeleteEvent}
         />
       )}
     </CalendarContainer>

--- a/src/components/Calendar/StudentReadTaskCard.js
+++ b/src/components/Calendar/StudentReadTaskCard.js
@@ -31,6 +31,7 @@ function StudentReadTaskCard({
   setAlertShow,
   selectedEvent,
   handleCancelEvent,
+  handleDeleteEvent,
 }) {
   const handleCloseClick = () => {
     setAlertShow(null);
@@ -61,6 +62,14 @@ function StudentReadTaskCard({
                 onClick={() => handleCancelEvent(selectedEvent.id)}
               >
                 取消此時段
+              </AlertButton>
+            )}
+            {selectedEvent.end.getTime() < new Date().getTime() && (
+              <AlertButton
+                color="#75A29E"
+                onClick={() => handleDeleteEvent(selectedEvent.id)}
+              >
+                刪除此筆課程紀錄
               </AlertButton>
             )}
           </>

--- a/src/pages/CartPage/CartPage.js
+++ b/src/pages/CartPage/CartPage.js
@@ -260,7 +260,7 @@ export default function CartPage() {
   }, [cartItems]);
 
   const deleteUserCartItem = async (scheduleId, setApiError) => {
-    let json = deleteCartItem(scheduleId, setApiError);
+    let json = await deleteCartItem(scheduleId, setApiError);
     if (!json && !json.success)
       return setApiError("發生了一點錯誤，請稍後再試");
   };

--- a/src/pages/CartPage/CartPage.js
+++ b/src/pages/CartPage/CartPage.js
@@ -260,7 +260,7 @@ export default function CartPage() {
   }, [cartItems]);
 
   const deleteUserCartItem = async (scheduleId, setApiError) => {
-    let json = await deleteCartItem(scheduleId, setApiError);
+    let json = deleteCartItem(scheduleId, setApiError);
     if (!json && !json.success)
       return setApiError("發生了一點錯誤，請稍後再試");
   };

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -117,6 +117,7 @@ function PointPage() {
     ReturnURL: "https://skilforapi.bocyun.tw/ecpay/callback",
     ChoosePayment: "Credit",
     EncryptType: "1",
+    ClientBackURL: "http://localhost:3000/SkilFor-Front/manage",
   });
   const pointInput = useRef(null);
   const checkout = useRef(null);
@@ -266,6 +267,12 @@ function PointPage() {
             name="PaymentType"
             id="PaymentType"
             value={orderData.PaymentType}
+          />
+          <input
+            type="hidden"
+            name="ClientBackURL"
+            id="ClientBackURL"
+            value="http://localhost:3000/SkilFor-Front/manage"
           />
           <input
             type="hidden"

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -7,6 +7,7 @@ import {
   generateCheckMacValue,
   getCurrentTime,
 } from "./utils";
+import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 
 const PointPageWrapper = styled(TeacherManageWrapper)``;
 const PriceCardContainer = styled.div`
@@ -21,11 +22,14 @@ const PriceContainer = styled.div`
   text-align: center;
   color: ${(props) => props.theme.colors.grey_dark};
   margin-right: 50px;
-  margin-top: 35px;
+  margin-top: 15px;
   padding: 20px 0 0 0;
   :hover {
     transform: translate(10px, -10px);
     transition: all 0.1s;
+  }
+  ${MEDIA_QUERY_SM} {
+    margin-right: 10px;
   }
 `;
 const PriceTitle = styled.h1`
@@ -104,6 +108,10 @@ const StorePointContainer = styled.div`
   display: flex;
   align-items: center;
 `;
+const CreditCardInfo = styled.p`
+  color: ${(props) => props.theme.colors.grey_dark};
+  margin-top: 10px;
+`;
 
 function PointPage() {
   const [orderData, setOrderData] = useState({
@@ -123,7 +131,7 @@ function PointPage() {
   const checkout = useRef(null);
   const handleStorePointClick = () => {
     let value = Number(pointInput.current.value);
-    if (value === "" || !(value > 0)) return;
+    if (value === "" || !(value >= 100)) return;
     let confirm = window.confirm(
       `這是你的選購資訊：自選儲值額度${value}點，需支付${value} 元，若確認無誤將導向刷卡頁面`
     );
@@ -158,7 +166,14 @@ function PointPage() {
   return (
     <PointPageWrapper>
       <PageTitle>點數儲值</PageTitle>
-      <SectionTitle className="first">優惠方案</SectionTitle>
+      <SectionTitle className="first">請用此測試信用卡號結帳</SectionTitle>
+      <CreditCardInfo>
+        🌚 注意！結帳時請使用下方測試信用卡資料，請勿輸入您真實的信用卡號 🌚
+      </CreditCardInfo>
+      <CreditCardInfo>信用卡測試卡號：4311-9522-2222-2222</CreditCardInfo>
+      <CreditCardInfo>信用卡測試安全碼：222</CreditCardInfo>
+      <CreditCardInfo>信用卡測試有效月/年：12/25</CreditCardInfo>
+      <SectionTitle>優惠方案</SectionTitle>
       <PriceCardContainer>
         <PriceCard
           title="初體驗"
@@ -189,12 +204,14 @@ function PointPage() {
           handleClick={() => handleChooseClick("超優惠方案", 10000, 12000)}
         />
       </PriceCardContainer>
-      <SectionTitle>自行選擇儲值金額 (一元兌換 1 point)</SectionTitle>
+      <SectionTitle>
+        自行選擇儲值金額 (一元兌換 1 point，儲值額度不得低於 100)
+      </SectionTitle>
       <StorePointContainer>
         <StorePointInput
           type="number"
           placeholder="請輸入儲值金額"
-          min="1"
+          min="100"
           ref={pointInput}
         />
         <StorePointButton onClick={handleStorePointClick}>
@@ -203,6 +220,7 @@ function PointPage() {
       </StorePointContainer>
       {orderData && (
         <form
+          target="_blank"
           ref={checkout}
           id="_form_aiochk"
           action="https://payment-stage.ecpay.com.tw/Cashier/AioCheckOut/V5"

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -116,7 +116,7 @@ const CreditCardInfo = styled.p`
 function PointPage() {
   const [orderData, setOrderData] = useState({
     MerchantID: "2000132",
-    MerchantTradeNo: createMerchantTradeNo(),
+    MerchantTradeNo: "",
     MerchantTradeDate: "",
     PaymentType: "aio",
     TotalAmount: 0,
@@ -138,6 +138,7 @@ function PointPage() {
     if (confirm) {
       let newPointOrder = {
         ...orderData,
+        MerchantTradeNo: createMerchantTradeNo(),
         MerchantTradeDate: getCurrentTime(),
         TotalAmount: value,
         ItemName: `自選儲值額度${value}點 ${value} 元 X1`,
@@ -152,6 +153,7 @@ function PointPage() {
     if (confirm) {
       let newPointOrder = {
         ...orderData,
+        MerchantTradeNo: createMerchantTradeNo(),
         MerchantTradeDate: getCurrentTime(),
         TotalAmount: price,
         ItemName: `${title}${points}點 ${price} 元 X1`,
@@ -171,8 +173,8 @@ function PointPage() {
         🌚 注意！結帳時請使用下方測試信用卡資料，請勿輸入您真實的信用卡號 🌚
       </CreditCardInfo>
       <CreditCardInfo>信用卡測試卡號：4311-9522-2222-2222</CreditCardInfo>
-      <CreditCardInfo>信用卡測試安全碼：222</CreditCardInfo>
       <CreditCardInfo>信用卡測試有效月/年：12/25</CreditCardInfo>
+      <CreditCardInfo>信用卡測試安全碼：222</CreditCardInfo>
       <SectionTitle>優惠方案</SectionTitle>
       <PriceCardContainer>
         <PriceCard

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 import PageTitle from "../../components/PageTitle";
 import { TeacherManageWrapper } from "../TeacherManagePage/TeacherManagePage";
@@ -103,46 +103,53 @@ const StorePointContainer = styled.div`
 
 function PointPage() {
   const [orderData, setOrderData] = useState({
+    MerchantID: "2000132",
     MerchantTradeNo: createMerchantTradeNo(),
-    PaymentType: "aio",
-    TotalAmount: "",
-    TradeDesc: "SkilFor課程點數儲值",
-    EncryptType: 1,
     MerchantTradeDate: new Date()
       .toLocaleString()
       .replace("上午", "")
       .replace("下午", ""),
-    MerchantID: "2000132",
+    PaymentType: "aio",
+    TotalAmount: 0,
+    TradeDesc: "SkilFor課程點數儲值",
     ItemName: "",
     ReturnURL: "https://skilforapi.bocyun.tw/ecpay/callback",
     ChoosePayment: "Credit",
+    EncryptType: "1",
   });
   const pointInput = useRef(null);
+  const checkout = useRef(null);
   const handleStorePointClick = () => {
     let value = Number(pointInput.current.value);
     if (value === "" || !(value > 0)) return;
-    let newPointOrder = {
-      ...orderData,
-      TotalAmount: value,
-      ItemName: `自選儲值額度 ${value} 元 X1`,
-    };
-    newPointOrder = {
-      ...newPointOrder,
-      CheckMacValue: generateCheckMacValue(newPointOrder),
-    };
-    setOrderData(newPointOrder);
+    let confirm = window.confirm(
+      `這是你的選購資訊：自選儲值額度${value}點，需支付${value} 元，若確認無誤將導向刷卡頁面`
+    );
+    if (confirm) {
+      let newPointOrder = {
+        ...orderData,
+        TotalAmount: value,
+        ItemName: `自選儲值額度${value}點 ${value} 元 X1`,
+      };
+      setOrderData(newPointOrder);
+    }
   };
+  useEffect(() => {
+    if (!orderData || orderData.ItemName === "") return;
+    checkout.current.submit();
+  }, [orderData]);
   const handleChooseClick = (title, price, points) => {
-    let newPointOrder = {
-      ...orderData,
-      TotalAmount: price,
-      ItemName: `${title}${points}點 ${price} 元 X1`,
-    };
-    newPointOrder = {
-      ...newPointOrder,
-      CheckMacValue: generateCheckMacValue(newPointOrder),
-    };
-    setOrderData(newPointOrder);
+    let confirm = window.confirm(
+      `這是你的選購資訊：${title}${points}點，需支付${price} 元，若確認無誤將導向刷卡頁面`
+    );
+    if (confirm) {
+      let newPointOrder = {
+        ...orderData,
+        TotalAmount: price,
+        ItemName: `${title}${points}點 ${price} 元 X1`,
+      };
+      setOrderData(newPointOrder);
+    }
   };
   return (
     <PointPageWrapper>
@@ -190,6 +197,82 @@ function PointPage() {
           儲值
         </StorePointButton>
       </StorePointContainer>
+      {orderData && (
+        <form
+          ref={checkout}
+          id="_form_aiochk"
+          action="https://payment-stage.ecpay.com.tw/Cashier/AioCheckOut/V5"
+          method="post"
+        >
+          <input
+            type="hidden"
+            name="MerchantTradeDate"
+            id="MerchantTradeDate"
+            value={orderData.MerchantTradeDate}
+          />
+          <input
+            type="hidden"
+            name="TotalAmount"
+            id="TotalAmount"
+            value={orderData.TotalAmount}
+          />
+          <input
+            type="hidden"
+            name="TradeDesc"
+            id="TradeDesc"
+            value={orderData.TradeDesc}
+          />
+          <input
+            type="hidden"
+            name="ItemName"
+            id="ItemName"
+            value={orderData.ItemName}
+          />
+          <input
+            type="hidden"
+            name="ReturnURL"
+            id="ReturnURL"
+            value={orderData.ReturnURL}
+          />
+          <input
+            type="hidden"
+            name="ChoosePayment"
+            id="ChoosePayment"
+            value={orderData.ChoosePayment}
+          />
+          <input
+            type="hidden"
+            name="MerchantTradeNo"
+            id="MerchantTradeNo"
+            value={orderData.MerchantTradeNo}
+          />
+          <input
+            type="hidden"
+            name="MerchantID"
+            id="MerchantID"
+            value={orderData.MerchantID}
+          />
+          <input
+            type="hidden"
+            name="EncryptType"
+            id="EncryptType"
+            value={orderData.EncryptType}
+          />
+          <input
+            type="hidden"
+            name="PaymentType"
+            id="PaymentType"
+            value={orderData.PaymentType}
+          />
+          <input
+            type="hidden"
+            name="CheckMacValue"
+            id="CheckMacValue"
+            value={generateCheckMacValue(orderData)}
+          />
+          {/* <input type="submit" /> */}
+        </form>
+      )}
     </PointPageWrapper>
   );
 }

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -1,7 +1,8 @@
-import React, { useRef } from "react";
+import React, { useState, useRef } from "react";
 import styled from "styled-components";
 import PageTitle from "../../components/PageTitle";
 import { TeacherManageWrapper } from "../TeacherManagePage/TeacherManagePage";
+import { createMerchantTradeNo, generateCheckMacValue } from "./utils";
 
 const PointPageWrapper = styled(TeacherManageWrapper)``;
 const PriceCardContainer = styled.div`
@@ -101,16 +102,47 @@ const StorePointContainer = styled.div`
 `;
 
 function PointPage() {
+  const [orderData, setOrderData] = useState({
+    MerchantTradeNo: createMerchantTradeNo(),
+    PaymentType: "aio",
+    TotalAmount: "",
+    TradeDesc: "SkilFor課程點數儲值",
+    EncryptType: 1,
+    MerchantTradeDate: new Date()
+      .toLocaleString()
+      .replace("上午", "")
+      .replace("下午", ""),
+    MerchantID: "2000132",
+    ItemName: "",
+    ReturnURL: "https://skilforapi.bocyun.tw/ecpay/callback",
+    ChoosePayment: "Credit",
+  });
   const pointInput = useRef(null);
   const handleStorePointClick = () => {
     let value = Number(pointInput.current.value);
     if (value === "" || !(value > 0)) return;
-    //將儲值金額發 API 給後端
-    console.log(value);
+    let newPointOrder = {
+      ...orderData,
+      TotalAmount: value,
+      ItemName: `自選儲值額度 ${value} 元 X1`,
+    };
+    newPointOrder = {
+      ...newPointOrder,
+      CheckMacValue: generateCheckMacValue(newPointOrder),
+    };
+    setOrderData(newPointOrder);
   };
-  const handleChooseClick = (price, points) => {
-    //將儲值金額發 API 給後端
-    console.log(price, points);
+  const handleChooseClick = (title, price, points) => {
+    let newPointOrder = {
+      ...orderData,
+      TotalAmount: price,
+      ItemName: `${title}${points}點 ${price} 元 X1`,
+    };
+    newPointOrder = {
+      ...newPointOrder,
+      CheckMacValue: generateCheckMacValue(newPointOrder),
+    };
+    setOrderData(newPointOrder);
   };
   return (
     <PointPageWrapper>
@@ -122,28 +154,28 @@ function PointPage() {
           price={250}
           points={300}
           courseCount="1"
-          handleClick={handleChooseClick}
+          handleClick={() => handleChooseClick("初體驗方案", 250, 300)}
         />
         <PriceCard
           title="小資族"
           price={3000}
           points={3500}
           courseCount="10"
-          handleClick={handleChooseClick}
+          handleClick={() => handleChooseClick("小資族方案", 3000, 3500)}
         />
         <PriceCard
           title="好划算"
           price={6000}
           points={7000}
           courseCount="20"
-          handleClick={handleChooseClick}
+          handleClick={() => handleChooseClick("好划算方案", 6000, 7000)}
         />
         <PriceCard
           title="超優惠"
           price={10000}
           points={12000}
           courseCount="35"
-          handleClick={handleChooseClick}
+          handleClick={() => handleChooseClick("超優惠方案", 10000, 12000)}
         />
       </PriceCardContainer>
       <SectionTitle>自行選擇儲值金額 (一元兌換 1 point)</SectionTitle>

--- a/src/pages/PointPage/PointPage.js
+++ b/src/pages/PointPage/PointPage.js
@@ -2,7 +2,11 @@ import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 import PageTitle from "../../components/PageTitle";
 import { TeacherManageWrapper } from "../TeacherManagePage/TeacherManagePage";
-import { createMerchantTradeNo, generateCheckMacValue } from "./utils";
+import {
+  createMerchantTradeNo,
+  generateCheckMacValue,
+  getCurrentTime,
+} from "./utils";
 
 const PointPageWrapper = styled(TeacherManageWrapper)``;
 const PriceCardContainer = styled.div`
@@ -105,10 +109,7 @@ function PointPage() {
   const [orderData, setOrderData] = useState({
     MerchantID: "2000132",
     MerchantTradeNo: createMerchantTradeNo(),
-    MerchantTradeDate: new Date()
-      .toLocaleString()
-      .replace("上午", "")
-      .replace("下午", ""),
+    MerchantTradeDate: "",
     PaymentType: "aio",
     TotalAmount: 0,
     TradeDesc: "SkilFor課程點數儲值",
@@ -128,8 +129,23 @@ function PointPage() {
     if (confirm) {
       let newPointOrder = {
         ...orderData,
+        MerchantTradeDate: getCurrentTime(),
         TotalAmount: value,
         ItemName: `自選儲值額度${value}點 ${value} 元 X1`,
+      };
+      setOrderData(newPointOrder);
+    }
+  };
+  const handleChooseClick = (title, price, points) => {
+    let confirm = window.confirm(
+      `這是你的選購資訊：${title}${points}點，需支付${price} 元，若確認無誤將導向刷卡頁面`
+    );
+    if (confirm) {
+      let newPointOrder = {
+        ...orderData,
+        MerchantTradeDate: getCurrentTime(),
+        TotalAmount: price,
+        ItemName: `${title}${points}點 ${price} 元 X1`,
       };
       setOrderData(newPointOrder);
     }
@@ -138,19 +154,6 @@ function PointPage() {
     if (!orderData || orderData.ItemName === "") return;
     checkout.current.submit();
   }, [orderData]);
-  const handleChooseClick = (title, price, points) => {
-    let confirm = window.confirm(
-      `這是你的選購資訊：${title}${points}點，需支付${price} 元，若確認無誤將導向刷卡頁面`
-    );
-    if (confirm) {
-      let newPointOrder = {
-        ...orderData,
-        TotalAmount: price,
-        ItemName: `${title}${points}點 ${price} 元 X1`,
-      };
-      setOrderData(newPointOrder);
-    }
-  };
   return (
     <PointPageWrapper>
       <PageTitle>點數儲值</PageTitle>
@@ -270,7 +273,6 @@ function PointPage() {
             id="CheckMacValue"
             value={generateCheckMacValue(orderData)}
           />
-          {/* <input type="submit" /> */}
         </form>
       )}
     </PointPageWrapper>

--- a/src/pages/PointPage/utils.js
+++ b/src/pages/PointPage/utils.js
@@ -9,7 +9,7 @@ export const generateCheckMacValue = (data) => {
   for (const key of keys) {
     checkValue += `${key}=${data[key]}&`;
   }
-  checkValue = `HashKey=${TEST_HASH_KEY}&${checkValue}HashIV=${TEST_HASH_IV}`; // There is already an & in the end of checkValue
+  checkValue = `HashKey=${TEST_HASH_KEY}&${checkValue}HashIV=${TEST_HASH_IV}`;
   checkValue = encodeURIComponent(checkValue).toLowerCase();
   checkValue = checkValue
     .replace(/%20/g, "+")
@@ -29,7 +29,7 @@ export const generateCheckMacValue = (data) => {
 
 export const createMerchantTradeNo = () => {
   let str = "";
-  for (let i = 0; i < 11; i++) {
+  for (let i = 0; i < 6; i++) {
     str += Math.ceil(Math.random() * 10);
   }
   str = "SkilFor" + str;

--- a/src/pages/PointPage/utils.js
+++ b/src/pages/PointPage/utils.js
@@ -35,3 +35,9 @@ export const createMerchantTradeNo = () => {
   str = "SkilFor" + str;
   return str;
 };
+
+export const getCurrentTime = () => {
+  let dateDataArr = new Date().toLocaleString().split(" ");
+  let timeDataArr = new Date().toTimeString().split(" ");
+  return dateDataArr[0] + " " + timeDataArr[0];
+};

--- a/src/pages/PointPage/utils.js
+++ b/src/pages/PointPage/utils.js
@@ -1,0 +1,37 @@
+import { enc } from "crypto-js";
+import sha256 from "crypto-js/sha256";
+const TEST_HASH_KEY = "5294y06JbISpM5x9";
+const TEST_HASH_IV = "v77hoKGq4kWxNNIS";
+
+export const generateCheckMacValue = (data) => {
+  const keys = Object.keys(data).sort();
+  let checkValue = "";
+  for (const key of keys) {
+    checkValue += `${key}=${data[key]}&`;
+  }
+  checkValue = `HashKey=${TEST_HASH_KEY}&${checkValue}HashIV=${TEST_HASH_IV}`; // There is already an & in the end of checkValue
+  checkValue = encodeURIComponent(checkValue).toLowerCase();
+  checkValue = checkValue
+    .replace(/%20/g, "+")
+    .replace(/%2d/g, "-")
+    .replace(/%5f/g, "_")
+    .replace(/%2e/g, ".")
+    .replace(/%21/g, "!")
+    .replace(/%2a/g, "*")
+    .replace(/%28/g, "(")
+    .replace(/%29/g, ")")
+    .replace(/%20/g, "+");
+
+  checkValue = sha256(checkValue).toString(enc.Hex);
+  checkValue = checkValue.toUpperCase();
+  return checkValue;
+};
+
+export const createMerchantTradeNo = () => {
+  let str = "";
+  for (let i = 0; i < 11; i++) {
+    str += Math.ceil(Math.random() * 10);
+  }
+  str = "SkilFor" + str;
+  return str;
+};

--- a/src/pages/StudentManagePage/StudentManagePage.js
+++ b/src/pages/StudentManagePage/StudentManagePage.js
@@ -36,7 +36,7 @@ function StudentManagePage() {
     };
     getData(setApiError);
   }, []);
-
+  console.log(studentInfos);
   const handleAlertOkClick = () => {
     setApiError(false);
     if (apiError === "請先登入才能使用後台功能") {
@@ -60,7 +60,13 @@ function StudentManagePage() {
         )}
         <UserInfoContainer>
           {studentInfos && (
-            <Avatar imgSrc={student} name={studentInfos.username} />
+            <Avatar
+              imgSrc={student}
+              name={studentInfos.username}
+              status={`我的點數：${
+                !studentInfos.points ? 0 : studentInfos.points
+              }`}
+            />
           )}
           <PageBtnsContainer>
             <PageBtn isClick={true}>個人資訊</PageBtn>

--- a/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/src/pages/TeacherManagePage/components/CoursePage.js
@@ -16,11 +16,7 @@ import {
 } from "./PageStyle";
 import PublishedRadiosContainer from "./PublishedRadiosContainer";
 import useEdit from "../hooks/useEdit";
-import {
-  registerNewCourse,
-  updateCourseInfos,
-  deleteCourse,
-} from "../../../WebAPI";
+import { updateCourseInfos, deleteCourse } from "../../../WebAPI";
 import { CATEGORY_LIST } from "../Constant";
 import { getKeyByValue } from "../../../utils";
 
@@ -183,11 +179,10 @@ function CoursePage({ apiError, setApiError }) {
         category: getKeyByValue(CATEGORY_LIST, editContent.category),
         audit: "pending",
       };
-      makeUpdateCourseApi(registerNewCourse, setApiError, updatedCourseInfos);
     } else {
       updatedCourseInfos = editContent;
-      makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
     }
+    makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
     updatedCourseInfos.category = CATEGORY_LIST[updatedCourseInfos.category];
     setCourseInfos(
       courseInfos.map((course) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,6 +3889,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz"


### PR DESCRIPTION
### Context
1. 點數儲值頁面串綠界金流與後端 API（產生訂單資料、打綠界 API、結帳完成後導回學生後台）
2. 學生後台頁面新增「我的點數」資料
3. 學生行事曆頁面新增學生刪除過期行程功能

### Notes
1. 請協助測試以下流程：於點數儲值頁面選擇點數方案 / 自選儲值金額  -> 於綠界完成信用卡刷卡流程 -> 輸入手機驗證碼完成結帳 -> 按下「返回店家」回到 SkilFor 學生後台(確認點數是否有增加)
2. 這筆 commit 請忽略「[feat] 修復刪除購物車item時出現的錯誤」，我會錯意了之後有改回原狀，所以檔案是沒有動到的狀態