### PR TITLE
新增管理員登入方式

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -410,7 +410,6 @@ export const deleteCartItem = async (scheduleId, setApiError) => {
         scheduleId,
       }),
     });
-    if (!res.ok) throw new Error("fail to fetch data");
     return await res.json();
   } catch (error) {
     return setApiError("發生了一點錯誤，請稍後再試");

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -95,7 +95,12 @@ function App() {
                 }
               />
               <Route path="/point" element={<PointPage />} />
-              <Route path="/admin" element={<AdminPage />} />
+              <Route
+                path="/admin"
+                element={
+                  user && user.identity === "administrator" && <AdminPage />
+                }
+              />
             </Routes>
             <Footer />
           </div>

--- a/src/components/BurgerMenu/BurgerMenu.js
+++ b/src/components/BurgerMenu/BurgerMenu.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { useState, useEffect, useContext } from "react";
+import { useState, useContext } from "react";
 import Icons from "../Icon/Icons";
 import { IconDiv } from "../Icon/IconDiv";
 import { MEDIA_QUERY_SM } from "../constants/breakpoints";
@@ -63,23 +63,26 @@ function BurgerMenu() {
   const [apiError, setApiError] = useState(false);
   const [userInfos, setUserInfos] = useState({});
 
-  useEffect(() => {
-    const getData = async (setApiError) => {
-      let json = await getUserInfos(setApiError);
-      if (!json || !json.success) {
-        return setApiError("發生了一點錯誤，請稍後再試");
-      }
-      return setUserInfos(json.data);
-    };
-    getData(setApiError);
-  }, [userInfos, setApiError]);
+  const handleBurgerClick = () => {
+    setMenu(!menu);
+    if (!menu) {
+      const getData = async (setApiError) => {
+        let json = await getUserInfos(setApiError);
+        if (!json || !json.success) {
+          return setApiError("發生了一點錯誤，請稍後再試");
+        }
+        setUserInfos(json.data);
+      };
+      getData(setApiError);
+    }
+  };
 
   return (
     <AuthMenuContext.Provider
       value={{ menuRef, menu, setMenu, handleMenuToggle }}
     >
       <Burger ref={menuRef}>
-        <BurgerBtn apiError={apiError} onClick={handleMenuToggle}>
+        <BurgerBtn apiError={apiError} onClick={handleBurgerClick}>
           <IconDiv>
             <Icons.NavIcons.Burger />
           </IconDiv>
@@ -101,12 +104,21 @@ function BurgerMenu() {
                 </BurgerItem>
               </>
             )}
-            <BurgerItem to="/calendar" onClick={handleMenuToggle}>
-              行事曆
-            </BurgerItem>
-            <BurgerItem to="/manage" onClick={handleMenuToggle}>
-              管理後台
-            </BurgerItem>
+            {user && user.identity !== "administrator" && (
+              <>
+                <BurgerItem to="/calendar" onClick={handleMenuToggle}>
+                  行事曆
+                </BurgerItem>
+                <BurgerItem to="/manage" onClick={handleMenuToggle}>
+                  管理後台
+                </BurgerItem>
+              </>
+            )}
+            {user && user.identity === "administrator" && (
+              <BurgerItem to="/admin" onClick={handleMenuToggle}>
+                審核頁面
+              </BurgerItem>
+            )}
           </BurgerContent>
         )}
       </Burger>

--- a/src/components/LoginRegisterForm/LoginRegisterFormItem.js
+++ b/src/components/LoginRegisterForm/LoginRegisterFormItem.js
@@ -65,7 +65,7 @@ export function FormItem({ itemName, id, value, type, name, handleChange }) {
     <FormItemContainer>
       <ItemName>
         {itemName}
-        {id === "password" && <span>(至少需有六碼)</span>}
+        {id === "password" && <span> (至少需有六碼)</span>}
       </ItemName>
       <ItemInput
         id={id}

--- a/src/components/LoginRegisterForm/useLogin.js
+++ b/src/components/LoginRegisterForm/useLogin.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { login, getMyUserData } from "../../WebAPI";
 import { setAuthToken } from "../../utils";
 import { AuthContext, AuthLoadingContext } from "../../contexts";
+import { scrollTop } from "../../utils";
 
 export default function useLogin() {
   const { setUser } = useContext(AuthContext);
@@ -67,12 +68,6 @@ export default function useLogin() {
         setIsLoading(false);
         navigate("/");
       });
-    });
-  };
-  const scrollTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
     });
   };
 

--- a/src/components/LoginRegisterForm/useLogin.js
+++ b/src/components/LoginRegisterForm/useLogin.js
@@ -37,6 +37,13 @@ export default function useLogin() {
       }
     }
 
+    if (loginData.email === "skilforAdmin@gmail.com") {
+      setLoginData({
+        ...loginData,
+        identity: "administrator",
+      });
+    }
+
     login(loginData, setErrorMessage).then((data) => {
       if (!data) {
         setIsLoading(false);
@@ -62,7 +69,7 @@ export default function useLogin() {
       });
     });
   };
-
+  console.log(loginData);
   const scrollTop = () => {
     window.scrollTo({
       top: 0,

--- a/src/components/LoginRegisterForm/useLogin.js
+++ b/src/components/LoginRegisterForm/useLogin.js
@@ -69,7 +69,6 @@ export default function useLogin() {
       });
     });
   };
-  console.log(loginData);
   const scrollTop = () => {
     window.scrollTo({
       top: 0,

--- a/src/components/LoginRegisterForm/useRegister.js
+++ b/src/components/LoginRegisterForm/useRegister.js
@@ -4,6 +4,7 @@ import { register } from "../../WebAPI";
 import { setAuthToken } from "../../utils";
 import { getMyUserData } from "../../WebAPI";
 import { AuthContext, AuthLoadingContext } from "../../contexts";
+import { scrollTop } from "../../utils";
 
 export default function useRegister() {
   const { setUser } = useContext(AuthContext);
@@ -78,13 +79,6 @@ export default function useRegister() {
         navigate("/");
         alert("恭喜成為新會員，您將獲得免費的上課點數 1000 點 !! ");
       });
-    });
-  };
-
-  const scrollTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
     });
   };
 

--- a/src/components/LoginRegisterForm/useRegister.js
+++ b/src/components/LoginRegisterForm/useRegister.js
@@ -76,6 +76,7 @@ export default function useRegister() {
         setUser(response.user);
         setIsLoading(false);
         navigate("/");
+        alert("恭喜成為新會員，您將獲得免費的上課點數 1000 點 !! ");
       });
     });
   };

--- a/src/pages/CartPage/CartList.js
+++ b/src/pages/CartPage/CartList.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import styled from "styled-components";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
-import close from "../../img/close.png";
+import deleteBtn from "../../img/close.png";
 
 const CheckBox = styled.input`
   width: 18px;
@@ -52,7 +52,6 @@ const ErrorTr = styled.tr`
   }
 `;
 const ExpiredCover = styled.div`
-  display: ${(props) => (props.show ? "block" : "none")};
   position: absolute;
   border-bottom: 1px solid #e6e6e6;
   background-color: rgba(0, 0, 0, 0.1);
@@ -77,10 +76,9 @@ export default function CartList({
   overlapTimeItems,
   orderError,
 }) {
-  const [expired, setExpired] = useState(false);
   const [errorNotice, setErrorNotice] = useState("");
   const [errorStyle, setErrorStyle] = useState({});
-
+  const [disabled, setDisable] = useState(false);
   useEffect(() => {
     function checkError() {
       setErrorNotice("");
@@ -89,7 +87,7 @@ export default function CartList({
         item.scheduleStatus ||
         new Date(item.start).getTime() < new Date().getTime()
       ) {
-        setExpired(true);
+        setDisable(true);
         setErrorStyle({
           backgroundColor: "#fafafa",
           color: "#AAAAAA",
@@ -105,11 +103,10 @@ export default function CartList({
           }
         });
       }
-
       if (orderError) {
         for (const [errorId, errorMessage] of Object.entries(orderError)) {
           if (errorId === item.scheduleId) {
-            setExpired(true);
+            setDisable(true);
             setErrorStyle({
               backgroundColor: "#fff59d",
             });
@@ -119,21 +116,21 @@ export default function CartList({
       }
     }
     checkError();
-  }, [item, expired, overlapTimeItems, orderError]);
+  }, [item, disabled, overlapTimeItems, orderError]);
 
   return (
     <>
       {item.scheduleStatus || errorNotice ? (
         <ErrorTr>
           <td colSpan="7">
-            <ExpiredCover show={expired} />
+            {item.scheduleStatus && <ExpiredCover />}
             {item.scheduleStatus ? item.scheduleStatus : errorNotice}
           </td>
         </ErrorTr>
       ) : null}
       <tr>
         <td data-title="購買" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           <label>
             <CheckBox
               type="checkbox"
@@ -141,45 +138,45 @@ export default function CartList({
               onClick={onClickCheck}
               checked={!!item.checked}
               id={item.scheduleId}
-              disabled={expired}
+              disabled={disabled}
             />
           </label>
         </td>
         <td data-title="刪除" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           <DeleteButton
-            src={close}
+            src={deleteBtn}
             onClick={onDeleteItem}
             id={item.scheduleId}
           />
         </td>
         <td data-title="課程名稱" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           {item.courseName}
         </td>
         <td data-title="老師" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           {item.teacherName}
         </td>
         <td data-title="上課時間" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           {getDisplayDate(new Date(item.start))}
           <br />
           {item.timePeriod}
         </td>
         <td data-title="點數" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           {item.price} 點
         </td>
         <td data-title="備註" style={errorStyle}>
-          <ExpiredCover show={expired} />
+          {item.scheduleStatus && <ExpiredCover />}
           <label>
             <NoteTextArea
               placeholder="我想對老師說..."
               onChange={onChangeNote}
               id={item.scheduleId}
               value={item.note || ""}
-              disabled={expired}
+              disabled={disabled}
             />
           </label>
         </td>

--- a/src/pages/CartPage/CartPage.js
+++ b/src/pages/CartPage/CartPage.js
@@ -7,7 +7,7 @@ import {
 } from "../../components/constants/breakpoints";
 import CartList from "../CartPage/CartList";
 //import { sleep } from "../../utils";
-//import { RESERVED_LIST, CART_LIST } from "./Constant";
+//import { CART_LIST } from "./Constant";
 import {
   getCartItems,
   deleteCartItem,
@@ -261,8 +261,9 @@ export default function CartPage() {
 
   const deleteUserCartItem = async (scheduleId, setApiError) => {
     let json = await deleteCartItem(scheduleId, setApiError);
-    if (!json && !json.success)
+    if (!json || !json.success) {
       return setApiError("發生了一點錯誤，請稍後再試");
+    }
   };
 
   const handleItemDelete = (e) => {
@@ -320,6 +321,7 @@ export default function CartPage() {
   const [orderError, setOrderError] = useState([]);
   const handleConfirmPaymentClick = (e) => {
     e.preventDefault();
+    if (orderError.length !== 0) return;
     const checkedItem = cartItems.find((item) => item.checked);
     if (!checkedItem) return alert("尚未選擇要確認購買的課程");
 

--- a/src/pages/CartPage/CartPage.js
+++ b/src/pages/CartPage/CartPage.js
@@ -359,9 +359,6 @@ export default function CartPage() {
       if (!json.success) {
         return setOrderError(json.errMessage);
       }
-      for (let i = 0; i < orderData.scheduleId.length; i++) {
-        deleteUserCartItem(orderData.scheduleId[i], setApiError);
-      }
       alert("成功扣點 ! 可在行事曆上看到已購買成功的課程喔");
       navigate("/calendar");
     });

--- a/src/pages/CartPage/CartPage.js
+++ b/src/pages/CartPage/CartPage.js
@@ -16,6 +16,7 @@ import {
 } from "../../WebAPI";
 import { checkEventsConflict } from "../../components/Calendar/utils";
 import { titles } from "./CartTableTitles";
+import { scrollTop } from "../../utils";
 
 const CartWrapper = styled.section`
   padding: 156px 80px 232px 80px;
@@ -187,6 +188,7 @@ const RemainingPoints = styled(TotalPoints)`
 `;
 
 export default function CartPage() {
+  scrollTop();
   const [cartItems, setCartItems] = useState([]);
   const [totalPoints, setTotalPoints] = useState("0");
   const [apiError, setApiError] = useState(false);

--- a/src/pages/FilterPage/FilterPage.js
+++ b/src/pages/FilterPage/FilterPage.js
@@ -12,6 +12,7 @@ import {
 } from "../../WebAPI";
 import { AuthMenuContext } from "../../contexts";
 import useMenu from "../../components/Menu/useMenu";
+import { scrollTop } from "../../utils";
 
 const Container = styled.div`
   padding: 125px 100px 160px 100px;
@@ -160,6 +161,7 @@ const ErrorBtn = styled.button`
 `;
 
 function FilterPage() {
+  scrollTop();
   const { menuRef, menu, setMenu, handleMenuToggle } = useMenu();
   const [filterError, setFilterError] = useState(false);
   const [dropdownContent, setDropdownContent] = useState([]);

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -7,6 +7,7 @@ import thirdStep from "../../img/third_step.jpg";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 import Typed from "typed.js";
 import { useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
 
 const Container = styled.div`
   padding: 100px 0px 100px 0px;
@@ -154,7 +155,7 @@ const TeacherStep = styled(Banner)`
   }
 `;
 
-const Btn = styled.button`
+const Btn = styled(Link)`
   border-radius: 40px;
   border: none;
   cursor: pointer;
@@ -168,6 +169,8 @@ const Btn = styled.button`
   box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.1);
   align-self: flex-end;
   font-size: 1.2rem;
+  text-decoration: none;
+  text-align: center;
   ${MEDIA_QUERY_SM} {
     padding: 10px;
     min-width: 120px;
@@ -239,14 +242,14 @@ function HomePage() {
               上課前會收到線上課程會議室連結，到了上課時間點選連結進入會議室，就可以開始享受與老師的上課啦！
             </StepDescription>
             <BtnDiv>
-              <FindATeacherBtn>開始找老師</FindATeacherBtn>
+              <FindATeacherBtn to="./filter">開始找老師</FindATeacherBtn>
             </BtnDiv>
           </StepContent>
         </StepDiv>
       </StudentStep>
       <TeacherStep src={teacherStep}>
         <p>上架你的才華，將熱情與技能分享給全世界</p>
-        <Btn>成為老師</Btn>
+        <Btn to="./register">成為老師</Btn>
       </TeacherStep>
     </Container>
   );

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -218,12 +218,16 @@ function HomePage() {
   const handleBtnClick = (e) => {
     e.preventDefault();
     if (!user || user.identity === "student") {
+      const confirmNavigate = window.confirm(
+        "註冊一個老師身分的帳號，即可成為老師囉 ! 按下確定將帶您前往註冊頁面。"
+      );
+      if (!confirmNavigate) return;
       setAuthToken("");
       setUser(null);
       navigate("/register");
     }
     if (user && user.identity === "teacher") {
-      navigate("/manage");
+      alert("您已成功成為老師囉 !");
     }
   };
   return (

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -8,6 +8,7 @@ import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 import Typed from "typed.js";
 import { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
+import { scrollTop } from "../../utils";
 
 const Container = styled.div`
   padding: 100px 0px 100px 0px;
@@ -193,6 +194,7 @@ const FindATeacherBtn = styled(Btn)`
 `;
 
 function HomePage() {
+  scrollTop();
   const newTyped = useRef(null);
   const typed = useRef(null);
 

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -7,8 +7,10 @@ import thirdStep from "../../img/third_step.jpg";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 import Typed from "typed.js";
 import { useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
-import { scrollTop } from "../../utils";
+import { Link, useNavigate } from "react-router-dom";
+import { scrollTop, setAuthToken } from "../../utils";
+import { AuthContext } from "../../contexts";
+import { useContext } from "react";
 
 const Container = styled.div`
   padding: 100px 0px 100px 0px;
@@ -211,6 +213,19 @@ function HomePage() {
     typed.current = new Typed(newTyped.current, typedSetting);
   }, []);
 
+  const { user, setUser } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const handleBtnClick = (e) => {
+    e.preventDefault();
+    if (!user || user.identity === "student") {
+      setAuthToken("");
+      setUser(null);
+      navigate("/register");
+    }
+    if (user && user.identity === "teacher") {
+      navigate("/manage");
+    }
+  };
   return (
     <Container>
       <Banner src={banner}>
@@ -251,7 +266,9 @@ function HomePage() {
       </StudentStep>
       <TeacherStep src={teacherStep}>
         <p>上架你的才華，將熱情與技能分享給全世界</p>
-        <Btn to="./register">成為老師</Btn>
+        <Btn to="./register" onClick={handleBtnClick}>
+          成為老師
+        </Btn>
       </TeacherStep>
     </Container>
   );

--- a/src/pages/LoginPage/LoginPage.js
+++ b/src/pages/LoginPage/LoginPage.js
@@ -13,8 +13,10 @@ import {
   ErrorMessage,
 } from "../../components/LoginRegisterForm/LoginRegisterFormWrapperStyle";
 import useLogin from "../../components/LoginRegisterForm/useLogin";
+import { scrollTop } from "../../utils";
 
 function LoginPage() {
+  scrollTop();
   const { handleLoginSubmit, loginData, handleLoginDataChange, errorMessage } =
     useLogin();
 

--- a/src/pages/RegisterPage/RegisterPage.js
+++ b/src/pages/RegisterPage/RegisterPage.js
@@ -13,8 +13,10 @@ import {
   ErrorMessage,
 } from "../../components/LoginRegisterForm/LoginRegisterFormWrapperStyle";
 import useRegister from "../../components/LoginRegisterForm/useRegister";
+import { scrollTop } from "../../utils";
 
 function RegisterPage() {
+  scrollTop();
   const {
     handleRegisterSubmit,
     registerData,

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,3 +23,10 @@ export const validateEmail = (email) => {
 export const getKeyByValue = (object, value) => {
   return Object.keys(object).find((key) => object[key] === value);
 };
+
+export const scrollTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth",
+  });
+};


### PR DESCRIPTION
**主要**
1. 新增管理員登入方式與權限 (因為 set identity state 非同步關係，需要按兩次登入按鈕才能成功以管理員身分登入，之後要再做調整)
2. 新增首頁兩個按鈕的連結
(如何成為老師的按鈕，因目前沒有放介紹如何成為老師的資訊，暫時以跳出 confirm 視窗來呈現)
3. 調整 burgermenu 拿使用者資料的時機，原本是在畫面 render 完就拿資料，但在 useEffect 的dependency 放 userInfos 會發生一直不斷打 get user info 的 api 問題。如果不放這個 dep，又會無法拿到使用者編輯過後的資料，除非使用者 re-render 畫面。現改為在使用者點擊 burgermenu 按鈕時就拿一次 user 的新資料，雖然第一次拿時會有點累格，但這樣才能在使用者改變點數或名字時就拿到最新資料。

**其他**
1. 調整購物車頁面，出現黃底錯誤可以點刪除按鈕，不能點確認購買按鈕
2. 較長的頁面加上 `scrollTop()` 自動回到畫面上面，不然換不同頁面要自己往上滑有點累
3. 加上註冊成功就 alert 免費點數
(**借問** 在 App.js 檔案中被 disable 的載入中我可以加回來了嗎? 因為註冊完帳號會先跳 alert 新點數才轉畫面，我找不到方法讓他相反過來，我覺得相反比較順。但也想說有加上載入中那個全版的 loading cover 應該就不會太奇怪 )