### PR TITLE
管理員後台：拿取資料功能、改變審核狀態功能  &  修復點數儲值頁面時間格式問題 & 其他細節項目調整

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -477,3 +477,21 @@ export const getOrderId = async (itemName, price, point) => {
     return error;
   }
 };
+//管理員後台
+export const getAdminCourses = async (audit) => {
+  let url = `${BASE_URL}/administrator/course?audit=${audit}`;
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) throw new Error("fail to fetch data");
+    return await res.json();
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -495,3 +495,24 @@ export const getAdminCourses = async (audit) => {
     return error;
   }
 };
+
+export const changeCourseAudit = async (courseId, newAudit) => {
+  let url = `${BASE_URL}/administrator/course`;
+  const token = getAuthToken();
+  try {
+    const res = await fetch(url, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        courseId: courseId,
+        changeStatus: newAudit,
+      }),
+    });
+    return await res.json();
+  } catch (error) {
+    return error;
+  }
+};

--- a/src/components/Calendar/ReadTaskAlertCard.js
+++ b/src/components/Calendar/ReadTaskAlertCard.js
@@ -59,9 +59,14 @@ function ReadTaskAlertCard({
       </TimeContainer>
       <ContentContainer>
         {selectedEvent.resource.reserved ? (
-          <AlertContent>
-            預約學生：{selectedEvent.resource.reserved}
-          </AlertContent>
+          <>
+            <AlertContent>
+              預約學生：{selectedEvent.resource.reserved}
+            </AlertContent>
+            <AlertContent>
+              課程視訊連結：https://explore.zoom.us/zh-tw/products/meetings/
+            </AlertContent>
+          </>
         ) : (
           <AlertContent>預約狀態：尚無人預約</AlertContent>
         )}

--- a/src/pages/AdminPage/AdminPage.js
+++ b/src/pages/AdminPage/AdminPage.js
@@ -10,7 +10,7 @@ import {
   SelectBar,
   ChooseCategoryButton,
 } from "../TeacherManagePage/components/CategoryDropDownMenu";
-import { sleep } from "../../utils";
+import { getAdminCourses } from "../../WebAPI";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 
 const AdminWrapper = styled.section`
@@ -131,7 +131,11 @@ function AdminPage() {
   const [showCourses, setShowCourses] = useState([]);
   useEffect(() => {
     async function getData() {
-      await sleep(500);
+      // getAdminCourses("pending").then((json) => {
+      //   if(json && json.success){
+
+      //   }
+      // });
       setAllCourses(courseData);
       let initData = courseData.filter((course) => course.audit === "pending");
       setShowCourses(initData);

--- a/src/pages/AdminPage/AdminPage.js
+++ b/src/pages/AdminPage/AdminPage.js
@@ -31,6 +31,7 @@ const GridItem = styled.div`
   align-items: center;
   border-bottom: 2px solid ${(props) => props.theme.colors.grey_bg};
   padding: 10px;
+  white-space: pre-wrap;
   color: ${(props) => props.theme.colors.grey_dark};
 `;
 

--- a/src/pages/AdminPage/AdminPage.js
+++ b/src/pages/AdminPage/AdminPage.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { MEDIA_QUERY_MD } from "../../components/constants/breakpoints";
 import PageTitle from "../../components/PageTitle";
-import { courseData } from "./constant";
 import { nanoid } from "nanoid";
 import {
   RowContainer,
@@ -22,7 +21,7 @@ const AdminWrapper = styled.section`
 
 const GridContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   text-align: center;
 `;
 
@@ -50,42 +49,56 @@ const handleAuditSubmit = (selectBar, courseId, audit) => {
   }
 };
 
+const SelectAuditContainer = styled(SelectContainer)`
+  margin-bottom: 0px;
+`;
+const ChooseAuditButton = styled(ChooseCategoryButton)``;
+
 const AuditDropDownMenu = ({ courseId, audit }) => {
   const selectBar = useRef(null);
   return (
-    <SelectContainer>
+    <SelectAuditContainer>
       <RowContainer>
-        <SelectBar ref={selectBar} defaultValue={audit}>
-          <option value="pending">審核中</option>
-          <option value="success">審核成功</option>
-          <option value="fail">審核失敗</option>
-        </SelectBar>
-        <ChooseCategoryButton
+        {audit === "pending" ? (
+          <SelectBar ref={selectBar} defaultValue={audit}>
+            <option value="pending">審核中</option>
+            <option value="success">審核成功</option>
+            <option value="fail">審核失敗</option>
+          </SelectBar>
+        ) : (
+          <SelectBar ref={selectBar} defaultValue={audit}>
+            <option value="success">審核成功</option>
+            <option value="fail">審核失敗</option>
+          </SelectBar>
+        )}
+        <ChooseAuditButton
           onClick={() => handleAuditSubmit(selectBar, courseId, audit)}
         >
           送出
-        </ChooseCategoryButton>
+        </ChooseAuditButton>
       </RowContainer>
-    </SelectContainer>
+    </SelectAuditContainer>
   );
 };
 
 const GridHead = () => {
   return (
     <>
-      <GridHeadItem>Course Name</GridHeadItem>
-      <GridHeadItem>Teacher</GridHeadItem>
+      <GridHeadItem>課程名稱</GridHeadItem>
+      <GridHeadItem>課程介紹</GridHeadItem>
+      <GridHeadItem>課程點數</GridHeadItem>
       <GridHeadItem>審核狀態</GridHeadItem>
     </>
   );
 };
-function GridRow({ courseId, courseName, teacher, audit }) {
+function GridRow({ course }) {
   return (
     <>
-      <GridItem>{courseName}</GridItem>
-      <GridItem>{teacher}</GridItem>
+      <GridItem>{course.courseName}</GridItem>
+      <GridItem>{course.courseDescription}</GridItem>
+      <GridItem>{course.price}</GridItem>
       <GridItem>
-        <AuditDropDownMenu courseId={courseId} audit={audit} />
+        <AuditDropDownMenu courseId={course.id} audit={course.audit} />
       </GridItem>
     </>
   );
@@ -126,28 +139,24 @@ const FilterButton = styled.button`
   `}
 `;
 function AdminPage() {
-  const [allCourses, setAllCourses] = useState([]);
   const [buttonType, setButtonType] = useState("pending");
   const [showCourses, setShowCourses] = useState([]);
+
   useEffect(() => {
     async function getData() {
-      // getAdminCourses("pending").then((json) => {
-      //   if(json && json.success){
-
-      //   }
-      // });
-      setAllCourses(courseData);
-      let initData = courseData.filter((course) => course.audit === "pending");
-      setShowCourses(initData);
+      getAdminCourses(buttonType).then((json) => {
+        if (json && json.success) {
+          setShowCourses(json.data);
+        }
+      });
     }
     getData();
-  }, []);
+  }, [buttonType]);
   const handleButtonClick = (e) => {
     let buttonId = e.target.id;
     setButtonType(buttonId);
-    let showData = allCourses.filter((course) => course.audit === buttonId);
-    setShowCourses(showData);
   };
+
   return (
     <AdminWrapper>
       <PageTitle>管理員後台</PageTitle>
@@ -177,13 +186,7 @@ function AdminPage() {
       <GridContainer>
         <GridHead />
         {showCourses.map((course) => (
-          <GridRow
-            key={nanoid()}
-            courseId={course.courseId}
-            courseName={course.courseName}
-            teacher={course.teacher}
-            audit={course.audit}
-          />
+          <GridRow key={nanoid()} course={course} />
         ))}
       </GridContainer>
     </AdminWrapper>

--- a/src/pages/PointPage/utils.js
+++ b/src/pages/PointPage/utils.js
@@ -37,7 +37,14 @@ export const createMerchantTradeNo = () => {
 };
 
 export const getCurrentTime = () => {
-  let dateDataArr = new Date().toLocaleString().split(" ");
-  let timeDataArr = new Date().toTimeString().split(" ");
-  return dateDataArr[0] + " " + timeDataArr[0];
+  var dt = new Date();
+  return `${dt.getFullYear().toString().padStart(4, "0")}/${(dt.getMonth() + 1)
+    .toString()
+    .padStart(2, "0")}/${dt.getDate().toString().padStart(2, "0")} ${dt
+    .getHours()
+    .toString()
+    .padStart(2, "0")}:${dt.getMinutes().toString().padStart(2, "0")}:${dt
+    .getSeconds()
+    .toString()
+    .padStart(2, "0")}`;
 };

--- a/src/pages/StudentManagePage/StudentManagePage.js
+++ b/src/pages/StudentManagePage/StudentManagePage.js
@@ -5,7 +5,6 @@ import Avatar from "../../components/Avatar";
 import PageTitle from "../../components/PageTitle";
 import SelfPage from "../TeacherManagePage/components/SelfPage";
 import useCheckToken from "../TeacherManagePage/hooks/useCheckToken";
-import student from "../../img/student1.png";
 import { getUserInfos } from "../../WebAPI.js";
 import AlertCard from "../../components/AlertCard/AlertCard";
 import {
@@ -36,7 +35,6 @@ function StudentManagePage() {
     };
     getData(setApiError);
   }, []);
-  console.log(studentInfos);
   const handleAlertOkClick = () => {
     setApiError(false);
     if (apiError === "請先登入才能使用後台功能") {
@@ -61,7 +59,7 @@ function StudentManagePage() {
         <UserInfoContainer>
           {studentInfos && (
             <Avatar
-              imgSrc={student}
+              imgSrc="https://i.imgur.com/f9bnLUM.png"
               name={studentInfos.username}
               status={`我的點數：${
                 !studentInfos.points ? 0 : studentInfos.points

--- a/src/pages/TeacherManagePage/TeacherManagePage.js
+++ b/src/pages/TeacherManagePage/TeacherManagePage.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
 import Avatar from "../../components/Avatar";
-import teacherPic from "../../img/teacher.jpeg";
 import PageTitle from "../../components/PageTitle";
 import CoursePage from "./components/CoursePage";
 import SelfPage from "./components/SelfPage";
@@ -132,7 +131,10 @@ function TeacherManagePage() {
         )}
         <UserInfoContainer>
           {teacherInfos && (
-            <Avatar imgSrc={teacherPic} name={teacherInfos.username} />
+            <Avatar
+              imgSrc="https://i.imgur.com/7AGhwxo.png"
+              name={teacherInfos.username}
+            />
           )}
           <PageBtnsContainer>
             <PageBtn

--- a/src/pages/TeacherManagePage/components/CourseInfosForm.js
+++ b/src/pages/TeacherManagePage/components/CourseInfosForm.js
@@ -26,6 +26,7 @@ export const ItemName = styled.p`
 export const ItemValue = styled(ItemName)`
   overflow-wrap: break-word;
   margin-bottom: 0px;
+  white-space: pre-wrap;
   display: ${(props) => (props.show ? "block" : "none")};
 `;
 export const EditInput = styled.input`

--- a/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/src/pages/TeacherManagePage/components/CoursePage.js
@@ -16,7 +16,11 @@ import {
 } from "./PageStyle";
 import PublishedRadiosContainer from "./PublishedRadiosContainer";
 import useEdit from "../hooks/useEdit";
-import { updateCourseInfos, deleteCourse } from "../../../WebAPI";
+import {
+  registerNewCourse,
+  updateCourseInfos,
+  deleteCourse,
+} from "../../../WebAPI";
 import { CATEGORY_LIST } from "../Constant";
 import { getKeyByValue } from "../../../utils";
 
@@ -179,10 +183,11 @@ function CoursePage({ apiError, setApiError }) {
         category: getKeyByValue(CATEGORY_LIST, editContent.category),
         audit: "pending",
       };
+      makeUpdateCourseApi(registerNewCourse, setApiError, updatedCourseInfos);
     } else {
       updatedCourseInfos = editContent;
+      makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
     }
-    makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
     updatedCourseInfos.category = CATEGORY_LIST[updatedCourseInfos.category];
     setCourseInfos(
       courseInfos.map((course) => {

--- a/src/pages/TeacherManagePage/components/SelfPage.js
+++ b/src/pages/TeacherManagePage/components/SelfPage.js
@@ -110,7 +110,7 @@ function SelfPage({ infos, setInfos, setApiError }) {
           </ItemBottom>
         )}
       </FormItemContainer>
-      <FormItemContainer show={!isEditing}>
+      {/* <FormItemContainer show={!isEditing}>
         <ItemTop>
           <ItemName>Avatar</ItemName>
         </ItemTop>
@@ -127,7 +127,7 @@ function SelfPage({ infos, setInfos, setApiError }) {
             )}
           </ItemBottom>
         )}
-      </FormItemContainer>
+      </FormItemContainer> */}
       <FormItemContainer show={!isEditing}>
         <ItemTop>
           <ItemName>Contact Email</ItemName>


### PR DESCRIPTION
### Context
1. 管理員後台：串拿取資料功能、改變審核狀態 API
2. 修復點數儲值頁面時間格式問題

細節項目調整：
1. 修復老師無法註冊新課程的問題
2. 調整老師課程頁面、管理員後台頁面的換行顯示
3. 老師行事曆頁面行程卡片新增視訊連結
4. 移除大頭貼可編輯的部分（目前因為沒串 imgur，所以先拔掉以預設的圖片顯示）

### Note
審核狀態僅能將審核中改為成功或失敗、審核成功改為審核失敗（審核失敗不能改狀態是因為要等老師再次送出編輯後的資料後，變成審核中才可以更改狀態）