### PR TITLE
管理員後台頁面：加上 API 錯誤處理、調整版面 ＆ 老師後台頁面修復審核失敗的課程無法送審的問題

### DIFF
--- a/src/WebAPI.js
+++ b/src/WebAPI.js
@@ -478,7 +478,7 @@ export const getOrderId = async (itemName, price, point) => {
   }
 };
 //管理員後台
-export const getAdminCourses = async (audit) => {
+export const getAdminCourses = async (audit, setApiError) => {
   let url = `${BASE_URL}/administrator/course?audit=${audit}`;
   const token = getAuthToken();
   try {
@@ -489,14 +489,13 @@ export const getAdminCourses = async (audit) => {
         Authorization: `Bearer ${token}`,
       },
     });
-    if (!res.ok) throw new Error("fail to fetch data");
     return await res.json();
   } catch (error) {
-    return error;
+    return setApiError("伺服器或網路錯誤");
   }
 };
 
-export const changeCourseAudit = async (courseId, newAudit) => {
+export const changeCourseAudit = async (courseId, newAudit, setApiError) => {
   let url = `${BASE_URL}/administrator/course`;
   const token = getAuthToken();
   try {
@@ -513,6 +512,6 @@ export const changeCourseAudit = async (courseId, newAudit) => {
     });
     return await res.json();
   } catch (error) {
-    return error;
+    return setApiError("伺服器或網路錯誤");
   }
 };

--- a/src/components/Calendar/ReadTaskAlertCard.js
+++ b/src/components/Calendar/ReadTaskAlertCard.js
@@ -44,6 +44,7 @@ function ReadTaskAlertCard({
     }
     if (!confirmAlert) return;
     deleteCalendarEvent(setApiError, selectedEvent.id).then((json) => {
+      if (!json) return setApiError("目前無法刪除課程時段，請稍後再試");
       if (json && !json.success) return setApiError(json.errMessage[0]);
       setAllEvents(allEvents.filter((event) => event.id !== selectedEvent.id));
     });

--- a/src/components/LoginRegisterForm/useLogin.js
+++ b/src/components/LoginRegisterForm/useLogin.js
@@ -67,7 +67,6 @@ export default function useLogin() {
   const handleLoginDataChange = (e) => {
     setErrorMessage("");
     const { name: inputName, value } = e.target;
-    console.log(value);
     setLoginData({
       ...loginData,
       [inputName]: value,

--- a/src/pages/AdminPage/AdminPage.js
+++ b/src/pages/AdminPage/AdminPage.js
@@ -11,6 +11,7 @@ import {
 } from "../TeacherManagePage/components/CategoryDropDownMenu";
 import { getAdminCourses, changeCourseAudit } from "../../WebAPI";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
+import AlertCard from "../../components/AlertCard/AlertCard";
 
 const ColumnContainer = styled.div`
   display: flex;
@@ -151,12 +152,16 @@ const FilterButton = styled.button`
 function AdminPage() {
   const [buttonType, setButtonType] = useState("pending");
   const [showCourses, setShowCourses] = useState([]);
+  const [apiError, setApiError] = useState(false);
 
   useEffect(() => {
     async function getData() {
-      getAdminCourses(buttonType).then((json) => {
+      getAdminCourses(buttonType, setApiError).then((json) => {
         if (json && json.success) {
           setShowCourses(json.data);
+        }
+        if (json && json.errorMessage) {
+          setApiError(json.errorMessage);
         }
       });
     }
@@ -170,15 +175,22 @@ function AdminPage() {
   const handleAuditSubmit = (selectBar, courseId, audit) => {
     let value = selectBar.current.value;
     if (value !== audit) {
-      changeCourseAudit(courseId, value).then((json) => {
-        if (json.success) {
+      changeCourseAudit(courseId, value, setApiError).then((json) => {
+        if (json && json.success) {
           let newShowCourses = showCourses.filter(
             (course) => course.id !== courseId
           );
           setShowCourses(newShowCourses);
         }
+        if (json && json.errorMessage) {
+          setApiError(json.errorMessage);
+        }
       });
     }
+  };
+
+  const handleAlertOkClick = () => {
+    return setApiError(false);
   };
 
   return (
@@ -208,6 +220,14 @@ function AdminPage() {
         </FilterButton>
       </ButtonsContainer>
       <GridContainer>
+        {apiError && (
+          <AlertCard
+            color="#A45D5D"
+            title="錯誤"
+            content={apiError}
+            handleAlertOkClick={handleAlertOkClick}
+          />
+        )}
         <GridHead />
         {showCourses.map((course) => (
           <GridRow

--- a/src/pages/AdminPage/AdminPage.js
+++ b/src/pages/AdminPage/AdminPage.js
@@ -12,6 +12,11 @@ import {
 import { getAdminCourses, changeCourseAudit } from "../../WebAPI";
 import { MEDIA_QUERY_SM } from "../../components/constants/breakpoints";
 
+const ColumnContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 const AdminWrapper = styled.section`
   padding: 156px 80px 232px 80px;
   ${MEDIA_QUERY_MD} {
@@ -45,13 +50,16 @@ const GridHeadItem = styled(GridItem)`
 const SelectAuditContainer = styled(SelectContainer)`
   margin-bottom: 0px;
 `;
-const ChooseAuditButton = styled(ChooseCategoryButton)``;
+const ChooseAuditButton = styled(ChooseCategoryButton)`
+  margin: 10px auto 0 auto;
+  width: fit-content;
+`;
 
 const AuditDropDownMenu = ({ courseId, audit, handleAuditSubmit }) => {
   const selectBar = useRef(null);
   return (
     <SelectAuditContainer>
-      <RowContainer>
+      <ColumnContainer>
         {audit === "pending" && (
           <SelectBar ref={selectBar} defaultValue={audit}>
             <option value="pending">審核中</option>
@@ -70,7 +78,7 @@ const AuditDropDownMenu = ({ courseId, audit, handleAuditSubmit }) => {
         >
           送出
         </ChooseAuditButton>
-      </RowContainer>
+      </ColumnContainer>
     </SelectAuditContainer>
   );
 };

--- a/src/pages/TeacherManagePage/components/CoursePage.js
+++ b/src/pages/TeacherManagePage/components/CoursePage.js
@@ -177,18 +177,32 @@ function CoursePage({ apiError, setApiError }) {
       return alert("尚有欄位未填答，請填寫完後再送出資料");
     }
     let updatedCourseInfos;
-    if (editContent.audit === "fail" || !editContent.audit) {
-      updatedCourseInfos = {
-        ...editContent,
-        category: getKeyByValue(CATEGORY_LIST, editContent.category),
-        audit: "pending",
-      };
-      makeUpdateCourseApi(registerNewCourse, setApiError, updatedCourseInfos);
-    } else {
-      updatedCourseInfos = editContent;
-      makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
+    let audit = editContent.audit;
+    switch (audit) {
+      case "success":
+        updatedCourseInfos = editContent;
+        makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
+        break;
+      case "fail":
+        updatedCourseInfos = {
+          ...editContent,
+          audit: "pending",
+          category: getKeyByValue(CATEGORY_LIST, editContent.category),
+        };
+        makeUpdateCourseApi(updateCourseInfos, setApiError, updatedCourseInfos);
+        updatedCourseInfos.category =
+          CATEGORY_LIST[updatedCourseInfos.category];
+        break;
+      default:
+        updatedCourseInfos = {
+          ...editContent,
+          audit: "pending",
+          category: getKeyByValue(CATEGORY_LIST, editContent.category),
+        };
+        makeUpdateCourseApi(registerNewCourse, setApiError, updatedCourseInfos);
+        updatedCourseInfos.category =
+          CATEGORY_LIST[updatedCourseInfos.category];
     }
-    updatedCourseInfos.category = CATEGORY_LIST[updatedCourseInfos.category];
     setCourseInfos(
       courseInfos.map((course) => {
         if (course.category !== editContent.category) {


### PR DESCRIPTION
### Context
1. 管理員後台頁面：加上 API 錯誤處理、調整版面（下拉式選單與送出按鈕改為 column 排列）
2. 修復老師課程管理後台審核失敗的課程無法再次送審的問題
3. 老師行事曆頁面：於刪除行程卡片加上拿不到 json 的錯誤處理